### PR TITLE
Fixed contribute.jsx

### DIFF
--- a/src/components/pages/hacktoberfest/contribute/contribute.jsx
+++ b/src/components/pages/hacktoberfest/contribute/contribute.jsx
@@ -15,21 +15,21 @@ const ITEMS = [
     title: 'Contributions<br/> to open issues',
     description:
       'We have a curated list of Hacktoberfest issues that are ready for you to pick up.',
-    url: '/',
+    url: 'https://github.com/novuhq/novu/issues',
   },
   {
     icon: buildIcon,
     title: 'Build a demo app',
     description:
       'Build a demo app of your choice using Novu to deliver notifications',
-    url: '/',
+    url: 'https://docs.novu.co/overview/introduction/',
   },
   {
     icon: blogIcon,
     title: 'Write a blog post',
     description:
       'Made a PR? Have used Novu in a recent project? Tell the world about it in form of an blog post, article or guide',
-    url: '/',
+    url: 'https://novu.co/blog/',
   },
   {
     icon: tutorialIcon,

--- a/src/components/pages/hacktoberfest/contribute/contribute.jsx
+++ b/src/components/pages/hacktoberfest/contribute/contribute.jsx
@@ -36,7 +36,7 @@ const ITEMS = [
     title: 'Make a tutorial',
     description:
       'Create a video tutorial or a written one, help new users and maintainers get started with Novu!',
-    url: '/',
+    url: 'https://docs.novu.co/overview/quick-start',
   },
 ];
 


### PR DESCRIPTION
Earlier, all the links were re-directing to novu.co, 

Fixed Broken Links in [website](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808)/[src](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808/src)/[components](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808/src/components)/[pages](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808/src/components/pages)/[hacktoberfest](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808/src/components/pages/hacktoberfest)/[contribute](https://github.com/novuhq/website/tree/b32cc96e7cfd02b8647106e1d925c9e0518ca808/src/components/pages/hacktoberfest/contribute)/contribute.jsx