### PR TITLE
Fix broken image on contributor profile share

### DIFF
--- a/src/components/pages/contributor/achievements/share/share.jsx
+++ b/src/components/pages/contributor/achievements/share/share.jsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { LinkedinShareButton, TwitterShareButton, FacebookShareButton } from 'react-share';
+import { useStaticQuery, graphql } from 'gatsby';
 
 import Button from 'components/shared/button';
 import Modal from 'components/shared/modal';

--- a/src/components/pages/contributor/achievements/share/share.jsx
+++ b/src/components/pages/contributor/achievements/share/share.jsx
@@ -51,7 +51,22 @@ export const Share = ({ type, imageUrl, url }) => {
   const buttonText = isSocialType ? 'Share' : 'Embed';
   const Icon = isSocialType ? ShareIcon : EmbedIcon;
 
-  const EMBED_CODE = `<a href="${url}"><img src="${imageUrl}" height="170" width="450" alt="" /></a>`;
+  const {
+    site: {
+      siteMetadata: { siteUrl, siteImage },
+    },
+  } = useStaticQuery(graphql`
+    query SEO {
+      site {
+        siteMetadata {
+          siteUrl
+          siteImage
+        }
+      }
+    }
+  `);
+
+  const EMBED_CODE = `<a href="${url}"><img src="${imageUrl}" height="170" width="450" alt="" onerror="this.onerror=null;this.src='${siteUrl + siteImage}';"/></a>`;
 
   const handleCloseModal = () => {
     setIsOpen(false);
@@ -91,6 +106,10 @@ export const Share = ({ type, imageUrl, url }) => {
           height={isSocialType ? 234 : 180}
           loading="eager"
           alt=""
+          onError={({ currentTarget }) => {
+            currentTarget.onerror = null;
+            currentTarget.src = siteUrl + siteImage;
+          }}
           aria-hidden
         />
 


### PR DESCRIPTION
fixes #40 
Currently, for the new contributors, the share and embed page shows a broken image.
This PR fixes the issue by showing default Novu social image if the share image hasn't been generated yet.