### PR TITLE
Fix: prevent cloud pricing slider overlapping tooltip

### DIFF
--- a/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
+++ b/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
@@ -197,7 +197,7 @@ const Cloud = ({ activeTier, setActiveTier, findActiveTier, rangeValue, setRange
             data-tooltip-content={tooltip}
           />
         </span>
-        <Tooltip className="z-50 max-w-[398px]" theme="white" />
+        <Tooltip className="max-w-[398px]" theme="white" />
       </div>
       <div className="relative mx-auto mt-12 w-full max-w-[968px]">
         <output

--- a/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
+++ b/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
@@ -197,7 +197,7 @@ const Cloud = ({ activeTier, setActiveTier, findActiveTier, rangeValue, setRange
             data-tooltip-content={tooltip}
           />
         </span>
-        <Tooltip className="max-w-[398px]" theme="white" />
+        <Tooltip className="z-50 max-w-[398px]" theme="white" />
       </div>
       <div className="relative mx-auto mt-12 w-full max-w-[968px]">
         <output

--- a/src/components/shared/tooltip/tooltip.jsx
+++ b/src/components/shared/tooltip/tooltip.jsx
@@ -18,7 +18,7 @@ const Tooltip = ({ className, id, theme }) => {
   return (
     isTooltipVisible && (
       <ReactTooltip
-        className={clsx('z-10 !rounded-lg !p-4 before:hidden', className, themeStyles[theme])}
+        className={clsx('z-20 !rounded-lg !p-4 before:hidden', className, themeStyles[theme])}
         place="top"
         effect="solid"
         id={id}


### PR DESCRIPTION
### Before my fix

At first look, everything looks right:

![at-first-look](https://github.com/novuhq/website/assets/43048524/5779a7d9-d487-4430-ae68-3200222e58e2)

But let's scroll down, and we can see slider overlapping tooltip

![tooltip-before](https://github.com/novuhq/website/assets/43048524/9a890ccf-2717-4685-a27d-046ef8ee751f)

### Slider and tooltip after my fix:

![tooltip-after](https://github.com/novuhq/website/assets/43048524/030cf650-7488-4c09-8969-4aaf69a5b4cb)
