### PR TITLE
fix: update the msteams provider card

### DIFF
--- a/src/components/pages/home/simple-use/simple-use.jsx
+++ b/src/components/pages/home/simple-use/simple-use.jsx
@@ -56,6 +56,7 @@ const CARDS = [
     icon: msTeams,
     title: 'MS Teams',
     text: 'Chat',
+    to: 'https://github.com/novuhq/novu/tree/main/providers/ms-teams'
   },
   {
     icon: aws,


### PR DESCRIPTION
The MS Teams provider was already implemented in the Novu. This PR fixes the provider card on the main page.

Before:
<img width="1711" alt="Screenshot 2023-09-06 at 22 16 58" src="https://github.com/novuhq/website/assets/2607232/4e257f91-3273-4c28-bcde-894cd6322445">
