### PR TITLE
Pricing Language, Meeting links, and UTM tags

### DIFF
--- a/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
+++ b/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
@@ -74,7 +74,7 @@ const getPricingData = (rangeValue) => [
       70: 2.0,
       90: 1.8,
     },
-    description: 'Good place for bigger projects, startups, and full-fledged businesses.',
+    description: 'Good place for bigger projects, startups, and businesses.',
     items: [`50k events/month included`],
     buttons: {
       default: {
@@ -103,8 +103,8 @@ const getPricingData = (rangeValue) => [
       90: 'TBC',
     },
     description:
-      'For bigger businesses, looking for Premium Enterprise Support, custom SLA’s, or very large deployments.',
-    items: [`5M events/month included`],
+      'For businesses that need Premium Enterprise Support, custom SLAs, and/or very large deployments.',
+    items: [`1M events/month included`],
     buttons: {
       default: {
         text: 'Contact sales',

--- a/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
+++ b/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
@@ -108,7 +108,7 @@ const getPricingData = (rangeValue) => [
     buttons: {
       default: {
         text: 'Contact sales',
-        url: 'https://calendly.com/novuhq/novu-meeting?utm_campaign=pricing-enterprise&utm_source=website',
+        url: 'https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=pricing-enterprise',
         onClick: () => {
           buttonClick('book_a_call', { type: 'enterprise_contact' });
           window?.analytics?.track('Pricing Event: Click the CTA Button on the card', {

--- a/src/components/pages/pricing/pricing-table/data/pricing-plans.js
+++ b/src/components/pages/pricing/pricing-table/data/pricing-plans.js
@@ -45,7 +45,7 @@ const PLANS = {
     linkUrl: LINKS.getStarted.to,
     common: {
       'monthly-triggers': '50K',
-      'additional-events': 'Scale to 50m+ events/month',
+      'additional-events': 'Scales to infinite events/month',
       rps: '600RPS',
       workflows: true,
       providers: true,

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -44,7 +44,7 @@ export default {
     target: '_blank',
   },
   inAppDocs: {
-    to: 'https://docs.novu.co/notification-center/introduction',
+    to: 'https://docs.novu.co/notification-center/introduction?utm_source=website',
     target: '_blank',
   },
   docker: {
@@ -56,7 +56,7 @@ export default {
     target: '_blank',
   },
   sdk: {
-    to: 'https://docs.novu.co/sdks/introduction',
+    to: 'https://docs.novu.co/sdks/introduction?utm_source=website',
     target: '_blank',
   },
   contactUs: {
@@ -64,15 +64,15 @@ export default {
     target: '_blank',
   },
   getStarted: {
-    to: 'https://web.novu.co',
+    to: 'https://web.novu.co?utm_source=website',
     target: '_blank',
   },
   quickStart: {
-    to: 'https://docs.novu.co/quickstarts/01-introduction',
+    to: 'https://docs.novu.co/quickstarts/01-introduction?utm_source=website',
     target: '_blank',
   },
   providers: {
-    to: 'https://docs.novu.co/channels-and-providers/introduction',
+    to: 'https://docs.novu.co/channels-and-providers/introduction?utm_source=website',
     target: '_blank',
   },
   handbook: {
@@ -104,11 +104,13 @@ export default {
     target: '_blank',
   },
   libraries: {
-    to: 'https://docs.novu.co/sdks/introduction',
+    to: 'https://docs.novu.co/sdks/introduction?utm_source=website',
     target: '_blank',
   },
+  //It still says calendly, but we're pointing it to Hubspot Meetings now
+  //old link: https://calendly.com/novuhq/novu-meeting?utm_campaign=main-page&utm_source=website
   calendly: {
-    to: 'https://calendly.com/novuhq/novu-meeting?utm_campaign=main-page&utm_source=website',
+    to: 'https://notify.novu.co/meetings/novuhq/notifications-45min?utm_source=website',
     target: '_blank',
   },
 

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -40,11 +40,11 @@ export default {
     target: '_blank',
   },
   careers: {
-    to: 'https://jobs.ashbyhq.com/novu.co?utm_source=website',
+    to: 'https://jobs.ashbyhq.com/novu.co?utm_campaign=website',
     target: '_blank',
   },
   inAppDocs: {
-    to: 'https://docs.novu.co/notification-center/introduction?utm_source=website',
+    to: 'https://docs.novu.co/notification-center/introduction?utm_campaign=website',
     target: '_blank',
   },
   docker: {
@@ -56,7 +56,7 @@ export default {
     target: '_blank',
   },
   sdk: {
-    to: 'https://docs.novu.co/sdks/introduction?utm_source=website',
+    to: 'https://docs.novu.co/sdks/introduction?utm_campaign=website',
     target: '_blank',
   },
   contactUs: {
@@ -64,15 +64,15 @@ export default {
     target: '_blank',
   },
   getStarted: {
-    to: 'https://web.novu.co?utm_source=website',
+    to: 'https://web.novu.co?utm_campaign=website',
     target: '_blank',
   },
   quickStart: {
-    to: 'https://docs.novu.co/quickstarts/01-introduction?utm_source=website',
+    to: 'https://docs.novu.co/quickstarts/01-introduction?utm_campaign=website',
     target: '_blank',
   },
   providers: {
-    to: 'https://docs.novu.co/channels-and-providers/introduction?utm_source=website',
+    to: 'https://docs.novu.co/channels-and-providers/introduction?utm_campaign=website',
     target: '_blank',
   },
   handbook: {
@@ -104,13 +104,13 @@ export default {
     target: '_blank',
   },
   libraries: {
-    to: 'https://docs.novu.co/sdks/introduction?utm_source=website',
+    to: 'https://docs.novu.co/sdks/introduction?utm_campaign=website',
     target: '_blank',
   },
   //It still says calendly, but we're pointing it to Hubspot Meetings now
-  //old link: https://calendly.com/novuhq/novu-meeting?utm_campaign=main-page&utm_source=website
+  //old link: https://calendly.com/novuhq/novu-meeting?utm_campaign=main-page&utm_campaign=website
   calendly: {
-    to: 'https://notify.novu.co/meetings/novuhq/notifications-45min?utm_source=website',
+    to: 'https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=website',
     target: '_blank',
   },
 


### PR DESCRIPTION
This PR does three things:
1) Changes some of the language on the /pricing page
2) Updates the calendly meeting links in the links file, as well as the /pricing page to use hubspot meetings instead
3) Updates multiple UTM tags across the site