### PR TITLE
Pricing page tweaks

### DIFF
--- a/src/components/pages/pricing/faq/faq.jsx
+++ b/src/components/pages/pricing/faq/faq.jsx
@@ -112,7 +112,7 @@ const FAQ_DATA = [
   {
     question: 'Can I use Novu free of charge?',
     answer:
-      'Yes, you can. If you send less than 10K events per month, then Novu Cloud is entirely free. Another option is to deploy the Open-Source version of Novu onto your own infrastructure, but that does not give you the unique SLA and global redundancy we have in the Cloud version of Novu.',
+      'Yes, you can. If you send less than 30K events per month, then Novu Cloud is entirely free. Another option is to deploy the Open-Source version of Novu onto your own infrastructure, but that does not give you the unique SLA and global redundancy we have in the Cloud version of Novu.',
   },
 ];
 

--- a/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
+++ b/src/components/pages/pricing/hero-with-cards/cloud/cloud.jsx
@@ -79,7 +79,7 @@ const getPricingData = (rangeValue) => [
     extraOvercharge: {
       20: 3.0,
       30: 3.0,
-      40: 2.8,
+      40: 2.35,
       50: 2.1,
       60: 1.62,
       70: 1.28,


### PR DESCRIPTION
Made two minor tweaks to the pricing page:

1) Updated the FAQ to reflect the new higher event limit for the free tier. It was 10k, it is now 30k events/month.
2) Updated the tiered pricing to correct one of the tiers to the correct (and lower) price.