### PR TITLE
fix: revert link to guides/workflows/introduction

### DIFF
--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -92,7 +92,7 @@ export default {
   // nestjs: { to: 'https://docs.novu.co/' }, -> We need to add this page
 
   // Getting started
-  howToGuides: { to: 'https://docs.novu.co/how-to/workflows/overview' },
+  howToGuides: { to: 'https://docs.novu.co/guides/workflows/introduction' },
   librariesAndSdks: { to: 'https://docs.novu.co/sdks/framework/typescript/overview' },
   integrations: { to: 'https://docs.novu.co/integrations/providers/introduction' },
 


### PR DESCRIPTION
fix the link until a further decision has been made on naming guides/howto/recipes