### PR TITLE
fix(components): styles for code snippet

### DIFF
--- a/src/components/pages/home/code/code-with-tooltip/code-with-tooltip.jsx
+++ b/src/components/pages/home/code/code-with-tooltip/code-with-tooltip.jsx
@@ -7,24 +7,17 @@ const TOOLTIP_CONTENT = {
     <span className="flex flex-col py-3.5">
       <span className="px-3.5 flex flex-col">
         <span className="whitespace-pre">
-          (alias) <span className="text-yellow">workflow</span>(id: string,
+          (alias) <span className="text-yellow">workflow</span>(
+        </span>
+        <span className="whitespace-pre">{'  '}id: string,</span>
+        <span className="whitespace-pre">
+          {'  '}execute: <span className="text-yellow">Execute</span>&lt;...&gt;,
         </span>
         <span className="whitespace-pre">
-          {' '}
-          <span className="whitespace-pre">
-            execute: <span className="text-yellow">Execute</span>&lt;...&gt;,
-          </span>
+          {'  '}options?: <span className="text-yellow">WorkflowOptions</span>&lt;...&gt;,
         </span>
         <span className="whitespace-pre">
-          {' '}
-          <span className="whitespace-pre">
-            options?: <span className="text-yellow">WorkflowOptions</span>&lt;...&gt;)
-          </span>
-        </span>
-        <span className="whitespace-pre">
-          <span className="whitespace-pre">
-            ): <span className="text-yellow">Workflow</span>&lt;...&gt;
-          </span>
+          ): <span className="text-yellow">Workflow</span>&lt;...&gt;
         </span>
       </span>
       <span className="my-3 mx-3.5 h-px bg-white/50" aria-hidden />
@@ -38,15 +31,16 @@ const TOOLTIP_CONTENT = {
           (parameter) <span className="text-yellow">controls</span>: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">subject</span>: string;
         </span>
         <span className="whitespace-pre">
-          {' '}
-          <span className="text-yellow">openAiModel</span>: "gpt-3.5-turbo" | "gpt-4o";
+          {'  '}
+          <span className="text-yellow">openAiModel</span>: &quot;gpt-3.5-turbo&quot; |
+          &quot;gpt-4o&quot;;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">aiPrompt</span>: string;
         </span>
         <span className="whitespace-pre">&#125;</span>
@@ -63,32 +57,32 @@ const TOOLTIP_CONTENT = {
           (parameter) <span className="text-yellow">event</span>: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">payload</span>: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
-          <span className="text-yellow">name</span>: string
+          {'    '}
+          <span className="text-yellow">name</span>: string;
         </span>
         <span className="whitespace-pre">
-          {' '}
-          <span className="text-yellow">comment</span>: string
+          {'    '}
+          <span className="text-yellow">comment</span>: string;
         </span>
-        <span className="whitespace-pre"> &#125;;</span>
+        <span className="whitespace-pre">{'  '}&#125;;</span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">step</span>: Step;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">subscriber</span>: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'    '}
           <span className="text-yellow">firstName</span>: string;
         </span>
-        <span className="whitespace-pre"> ...</span>
-        <span className="whitespace-pre"> &#125;;</span>
+        <span className="whitespace-pre">{'    '}...</span>
+        <span className="whitespace-pre">{'  '}&#125;;</span>
         <span>&#125;</span>
       </span>
       <span className="my-3 mx-3.5 h-px bg-white/50" aria-hidden />
@@ -114,31 +108,34 @@ const TOOLTIP_CONTENT = {
           (property) <span className="text-yellow">trigger</span>: (event: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">payload</span>: &#123;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'    '}
           <span className="text-yellow">name</span>: string;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'    '}
           <span className="text-yellow">comment</span>: string;
         </span>
-        <span className="whitespace-pre"> &#125;;</span>
+        <span className="whitespace-pre">{'  '}&#125;;</span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">to</span>: Recipients;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">actor?</span>: Actor | undefined;
         </span>
         <span className="whitespace-pre">
-          {' '}
+          {'  '}
           <span className="text-yellow">tenant?</span>: Tenant | undefined;
         </span>
-        <span className="whitespace-pre">&#125;){` => Promise`}&lt;...&gt;</span>
+        <span className="whitespace-pre">
+          &#125;){` => `}
+          <span className="text-yellow">Promise</span>&lt;...&gt;
+        </span>
       </span>
       <span className="my-3 mx-3.5 h-px bg-white/50" aria-hidden />
       <span className="px-3.5">Trigger a notification workflow.</span>

--- a/src/components/pages/home/code/code.jsx
+++ b/src/components/pages/home/code/code.jsx
@@ -67,7 +67,7 @@ const Code = () => {
           className="relative z-10 text-[44px] leading-none tracking-snug font-medium text-transparent max-w-[700px] bg-clip-text bg-[linear-gradient(360deg,rgba(104,181,215,1)_-19.23%,#FFFFFF_30.54%)] ml-[42px] lg:text-5xl lg:ml-8 md:text-4xl md:max-w-md md:ml-0 sm:text-[32px]"
           dangerouslySetInnerHTML={{ __html: TITLE }}
         />
-        <p className="mt-4 text-[17px] leading-snug font-book text-gray-9 max-w-[800px] ml-[42px] lg:mt-2.5 md:text-base md:mt-3">
+        <p className="mt-4 text-[17px] leading-snug font-book text-gray-9 max-w-[800px] ml-[42px] lg:ml-8 md:ml-0 lg:mt-2.5 md:text-base md:mt-3">
           {DESCRIPTION}
         </p>
         <ul className="relative z-10 flex justify-end gap-x-7 font-medium text-[15px] text-[#CAE9FF]/60 leading-snug mt-8 pr-8 lg:mt-5 lg:gap-x-6 md:text-sm md:mt-4 md:pr-0 md:gap-x-[22px] sm:justify-start sm:mt-[30px]">

--- a/src/components/pages/home/code/code.jsx
+++ b/src/components/pages/home/code/code.jsx
@@ -105,11 +105,11 @@ const Code = () => {
             {code}
           </SyntaxHighlighter>
           <StaticImage
-            className="!absolute pointer-events-none bottom-[-65px] right-0 z-0 w-[1152px] lg:bottom-[-43px] lg:w-[960px] md:!hidden"
+            className="!absolute pointer-events-none bottom-[-73px] right-0 z-0 w-[1252px] lg:bottom-[-46px] lg:w-[1044px] md:!hidden"
             src="./images/code-background.png"
             alt=""
-            width={1152}
-            height={652}
+            width={1252}
+            height={766}
             quality={100}
           />
           <StaticImage


### PR DESCRIPTION
**What?**
* Fix the positioning of the code snippet background image
* Use consistent spacing for the tooltip code popover snippets

**Screens**
_Large_
<img width="1193" alt="image" src="https://github.com/novuhq/website/assets/32132657/625b320c-2b09-40d6-a797-87f0a633679d">

_Medium_
<img width="1071" alt="image" src="https://github.com/novuhq/website/assets/32132657/24a61d90-4a6e-46b6-925f-a22539d2426d">

_Small_
<img width="663" alt="image" src="https://github.com/novuhq/website/assets/32132657/5609a2b4-c40c-4ace-bd89-4995c309752e">

_Extra Small_
<img width="462" alt="image" src="https://github.com/novuhq/website/assets/32132657/32e7cb21-9bc3-454c-8b44-24718c758af2">
