### PR TITLE
chore: update meeting link

### DIFF
--- a/src/components/pages/add-notifications/cta/cta.jsx
+++ b/src/components/pages/add-notifications/cta/cta.jsx
@@ -13,7 +13,7 @@ import buttonClick from 'utils/use-landing-simple-tracking';
 
 const LINK = {
   text: 'Book Meeting',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-addNotification',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-addNotification',
   target: '_blank',
 };
 

--- a/src/components/pages/content-management/cta/cta.jsx
+++ b/src/components/pages/content-management/cta/cta.jsx
@@ -15,7 +15,7 @@ const DESCRIPTION =
 
 const LINK = {
   text: 'Book Meeting',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-contentManagement',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-contentManagement',
   target: '_blank',
 };
 

--- a/src/components/pages/home/cta/cta.jsx
+++ b/src/components/pages/home/cta/cta.jsx
@@ -15,7 +15,7 @@ const DESCRIPTION =
 
 const LINK = {
   text: 'Book Session',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-homeCTA',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-homeCTA',
 };
 
 const CODE = 'npx novu@latest dev';

--- a/src/components/pages/improve-communication-experience/cta/cta.jsx
+++ b/src/components/pages/improve-communication-experience/cta/cta.jsx
@@ -12,7 +12,7 @@ import buttonClick from 'utils/use-landing-simple-tracking';
 
 const LINK = {
   text: 'Book Meeting',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-improveComms',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-improveComms',
   target: '_blank',
 };
 

--- a/src/components/pages/multi-channel-notifications/cta/cta.jsx
+++ b/src/components/pages/multi-channel-notifications/cta/cta.jsx
@@ -12,7 +12,7 @@ import buttonClick from 'utils/use-landing-simple-tracking';
 
 const LINK = {
   text: 'Book Meeting',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-multiChannel',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-multiChannel',
   target: '_blank',
 };
 

--- a/src/components/pages/unified-platform/cta/cta.jsx
+++ b/src/components/pages/unified-platform/cta/cta.jsx
@@ -14,7 +14,7 @@ const DESCRIPTION =
 
 const LINK = {
   text: 'Book Meeting',
-  url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-unifiedPlatform',
+  url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-unifiedPlatform',
   target: '_blank',
 };
 

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -205,15 +205,19 @@ export default {
   // It still says calendly, but we're pointing it to Hubspot Meetings now
   // old link: https://calendly.com/novuhq/novu-meeting?utm_campaign=main-page&utm_campaign=website
   calendly: {
-    to: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website',
+    to: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website',
+    target: '_blank',
+  },
+  previousBAM: {
+    to: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr',
     target: '_blank',
   },
   BAM: {
-    to: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website',
+    to: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website',
     target: '_blank',
   },
   bamCTA: {
-    to: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-cta-bottom',
+    to: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-cta-bottom',
     target: '_blank',
   },
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -204,7 +204,7 @@ const HomePage = () => (
       }}
       rightItem={{
         text: 'BOOK A DEMO',
-        link: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=ws-cta',
+        link: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=ws-cta',
       }}
     />
     <Flexibility />

--- a/src/pages/usecases/add-notifications.jsx
+++ b/src/pages/usecases/add-notifications.jsx
@@ -28,7 +28,7 @@ const addNotificationsPage = () => (
         },
         {
           text: 'Book Meeting',
-          url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-addNotification',
+          url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-addNotification',
           target: '_blank',
         },
       ]}

--- a/src/pages/usecases/content-management.jsx
+++ b/src/pages/usecases/content-management.jsx
@@ -28,7 +28,7 @@ const contentManagementPage = () => (
         },
         {
           text: 'Book Meeting',
-          url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-contentManagement',
+          url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-contentManagement',
           target: '_blank',
         },
       ]}

--- a/src/pages/usecases/improve-communication-experience.jsx
+++ b/src/pages/usecases/improve-communication-experience.jsx
@@ -28,7 +28,7 @@ const improveCommunicationExperiencePage = () => (
         },
         {
           text: 'Book Meeting',
-          url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-improveComms',
+          url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-improveComms',
           target: '_blank',
         },
       ]}

--- a/src/pages/usecases/multi-channel-notifications.jsx
+++ b/src/pages/usecases/multi-channel-notifications.jsx
@@ -28,7 +28,7 @@ const MultiChannelNotificationsPage = () => (
         },
         {
           text: 'Book Meeting',
-          url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-multiChannel',
+          url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-multiChannel',
           target: '_blank',
         },
       ]}

--- a/src/pages/usecases/unified-platform.jsx
+++ b/src/pages/usecases/unified-platform.jsx
@@ -28,7 +28,7 @@ const unifiedPlatformPage = () => (
         },
         {
           text: 'Book Meeting',
-          url: 'https://notify.novu.co/meetings/novumeet/discovery-session?utm_campaign=website-usecase-unifiedPlatform',
+          url: 'https://notify.novu.co/meetings/novuhq/novu-discovery-session-rr?utm_campaign=website-usecase-unifiedPlatform',
           target: '_blank',
         },
       ]}


### PR DESCRIPTION
Moves meeting link from group-based to RR

Todo in the future:
- Make this a local redirect so we only edit it in one place.
- Separately build out two prod meeting request links: one round robin, and the other group-based