### PR TITLE
fix: exclude symbols from id

### DIFF
--- a/src/components/pages/blog-post/table-of-contents/table-of-contents.jsx
+++ b/src/components/pages/blog-post/table-of-contents/table-of-contents.jsx
@@ -54,7 +54,7 @@ const TableOfContents = ({ headings }) => {
 
           const text = headingText.join(' ');
 
-          const id = slugify(text, { lower: true, remove: /[*+~.()'"!:@/]/g });
+          const id = slugify(text, { lower: true, remove: /[*+~.()'"!:@/?]/g });
           return (
             <li className="group flex" key={id}>
               <Link

--- a/src/components/shared/cookie-banner/cookie-banner.jsx
+++ b/src/components/shared/cookie-banner/cookie-banner.jsx
@@ -56,25 +56,27 @@ const CookieBanner = ({ isCookieBannerVisible, setIsCookieBannerVisible }) => {
         {isCookieBannerVisible && (
           <>
             <m.div
-              className="fixed bottom-6 left-0 right-0 mx-auto z-40 max-w-[354px] overflow-hidden rounded-[10px] border border-[rgba(255,255,255,0.15)] px-5 py-[18px] before:absolute before:inset-0 before:-z-10 before:bg-[linear-gradient(180deg,rgba(26,26,26,0.4)_0%,rgba(26,26,26,0.28)_100%)] before:backdrop-blur-[15px] sm:bottom-0 sm:left-0 sm:w-full sm:max-w-none sm:rounded-none sm:border-b-0 sm:border-l-0 sm:border-r-0 sm:px-4 sm:py-4"
+              className="fixed bottom-6 left-0 right-0 mx-auto z-40 max-w-[354px] overflow-hidden rounded-[10px] border border-[rgba(255,255,255,0.15)] px-5 py-[18px] before:absolute before:inset-0 before:bg-[linear-gradient(180deg,rgba(26,26,26,0.4)_0%,rgba(26,26,26,0.28)_100%)] before:backdrop-blur-[15px] sm:bottom-0 sm:left-0 sm:w-full sm:max-w-none sm:rounded-none sm:border-b-0 sm:border-l-0 sm:border-r-0 sm:px-4 sm:py-4"
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 30 }}
               transition={{ duration: 0.5, delay: 0.5 }}
             >
-              <p className="text-sm leading-tight text-gray-8 sm:text-center">{TEXT}</p>
+              <div className="relative z-10">
+                <p className="text-sm leading-tight text-gray-8 sm:text-center">{TEXT}</p>
 
-              <div className="mt-4 flex items-center justify-between sm:justify-center sm:gap-x-5">
-                <Link tag="button" theme="white-underline" size="xxs" onClick={handleOpenModal}>
-                  Manage
-                </Link>
-                <div className="flex gap-x-3">
-                  <Button theme="gray-outline" size="xxs" onClick={handleDeclineClick}>
-                    Decline
-                  </Button>
-                  <Button theme="primary" size="xxs" onClick={handleAcceptClick}>
-                    Accept
-                  </Button>
+                <div className="mt-4 flex items-center justify-between sm:justify-center sm:gap-x-5">
+                  <Link tag="button" theme="white-underline" size="xxs" onClick={handleOpenModal}>
+                    Manage
+                  </Link>
+                  <div className="flex gap-x-3">
+                    <Button theme="gray-outline" size="xxs" onClick={handleDeclineClick}>
+                      Decline
+                    </Button>
+                    <Button theme="primary" size="xxs" onClick={handleAcceptClick}>
+                      Accept
+                    </Button>
+                  </div>
                 </div>
               </div>
             </m.div>

--- a/src/utils/get-react-content-with-lazy-blocks.jsx
+++ b/src/utils/get-react-content-with-lazy-blocks.jsx
@@ -101,7 +101,7 @@ export default function getReactContentWithLazyBlocks(content, pageComponents, i
             return acc;
           }, '');
 
-          const id = slugify(text, { lower: true, remove: /[*+~.()'"!:@/]/g });
+          const id = slugify(text, { lower: true, remove: /[*+~.()'"!:@/?]/g });
 
           domNode.attribs.id = id;
         }


### PR DESCRIPTION
This PR excludes symbols `?` and `!` from `id` for Table of Contents in Blog posts.