### PR TITLE
fix: reusable sections styles

### DIFF
--- a/src/components/shared/reusable-sections/get-involved/get-involved.jsx
+++ b/src/components/shared/reusable-sections/get-involved/get-involved.jsx
@@ -14,7 +14,7 @@ const GetInvolved = ({ title, items, bottomMargin }) => (
   >
     <div className="container-md px-8 sm:w-full sm:px-5">
       <Heading
-        className="text-center font-medium leading-denser tracking-snug lg:text-[32px] md:text-3xl"
+        className="text-pretty text-center font-medium leading-denser tracking-snug lg:text-[32px] md:text-3xl"
         tag="h2"
         size="lg"
         theme="white"
@@ -24,7 +24,13 @@ const GetInvolved = ({ title, items, bottomMargin }) => (
       <ul className="mt-14 grid grid-cols-3 gap-x-16 lg:mt-12 lg:max-w-none lg:gap-x-[52px] lg:px-9 md:mt-10 md:gap-x-7 md:gap-y-8 md:px-0 sm:mt-8 sm:grid-cols-1 sm:gap-7">
         {items.map(({ icon, title, description, linkText, linkUrl }, index) => (
           <li key={index} className="flex flex-col items-center">
-            <img className="w-auto md:size-9 sm:size-8" src={icon} alt="" width={40} height={40} />
+            <img
+              className="size-10 w-auto md:size-9 sm:size-8"
+              src={icon}
+              alt=""
+              width={40}
+              height={40}
+            />
             <h3 className="mt-5 text-center text-2xl font-medium leading-tight tracking-snug lg:text-2xl md:mt-5 md:text-xl sm:mt-4">
               {title}
             </h3>

--- a/src/components/shared/reusable-sections/section-with-video/section-with-video.jsx
+++ b/src/components/shared/reusable-sections/section-with-video/section-with-video.jsx
@@ -6,7 +6,15 @@ import Heading from 'components/shared/heading';
 
 import transcriptBorderGlow from './images/transcript-border-glow.svg';
 
-const SectionWithVideo = ({ video, title, description, videoPosition, transcription }) => {
+const SectionWithVideo = ({
+  video,
+  title,
+  description,
+  videoPosition,
+  transcription,
+  id,
+  className,
+}) => {
   const getVideoComponent = () => {
     switch (video.type) {
       case 'youtube':
@@ -44,7 +52,13 @@ const SectionWithVideo = ({ video, title, description, videoPosition, transcript
   };
 
   return (
-    <section className="section-with-video safe-paddings mt-40 lg:mt-[120px] md:mt-[100px] sm:mt-20">
+    <section
+      className={clsx(
+        'section-with-video safe-paddings mt-40 lg:mt-[120px] md:mt-[100px] sm:mt-20',
+        className
+      )}
+      id={id}
+    >
       <div
         className={clsx(
           'container-lg flex items-center justify-center gap-x-16 lg:gap-x-12 md:flex-col',
@@ -119,11 +133,15 @@ SectionWithVideo.propTypes = {
   description: PropTypes.string.isRequired,
   videoPosition: PropTypes.oneOf(['left', 'right', 'fullWidth']),
   transcription: PropTypes.arrayOf(PropTypes.string),
+  id: PropTypes.string,
+  className: PropTypes.string,
 };
 
 SectionWithVideo.defaultProps = {
   videoPosition: 'right',
   transcription: null,
+  id: null,
+  className: null,
 };
 
 export default SectionWithVideo;

--- a/src/pages/landing/get-started.jsx
+++ b/src/pages/landing/get-started.jsx
@@ -78,16 +78,16 @@ const GSLandingPage = () => (
       }}
       theme="purple"
     />
-    <a id="video">
-      <SectionWithVideo
-        video={{
-          type: 'youtube',
-          url: 'https://www.youtube.com/watch?v=A1ciB-LgY8w&ab_channel=Novu',
-        }}
-        title="If you're ready to write osme Javascript and get notifying"
-        description="This video walks you through all the important details to get your local dev environment up and running and code your first workflow."
-      />
-    </a>
+    <SectionWithVideo
+      video={{
+        type: 'youtube',
+        url: 'https://www.youtube.com/watch?v=A1ciB-LgY8w&ab_channel=Novu',
+      }}
+      title="If you're ready to write some Javascript and get notifying"
+      description="This video walks you through all the important details to get your local dev environment up and running and code your first workflow."
+      id="video"
+      className="pb-40 md:pb-20"
+    />
   </Layout>
 );
 

--- a/src/pages/landing/react-email-blocks.jsx
+++ b/src/pages/landing/react-email-blocks.jsx
@@ -78,16 +78,16 @@ const GSLandingPage = () => (
       }}
       theme="purple"
     />
-    <a id="video">
-      <SectionWithVideo
-        video={{
-          type: 'youtube',
-          url: 'https://www.youtube.com/watch?v=A1ciB-LgY8w&ab_channel=Novu',
-        }}
-        title="If you're ready to write osme Javascript and get notifying"
-        description="This video walks you through all the important details to get your local dev environment up and running and code your first workflow."
-      />
-    </a>
+    <SectionWithVideo
+      video={{
+        type: 'youtube',
+        url: 'https://www.youtube.com/watch?v=A1ciB-LgY8w&ab_channel=Novu',
+      }}
+      title="If you're ready to write some Javascript and get notifying"
+      description="This video walks you through all the important details to get your local dev environment up and running and code your first workflow."
+      id="video"
+      className="pb-40 md:pb-20"
+    />
   </Layout>
 );
 


### PR DESCRIPTION
This PR brings reusable sections styles fix:

1. Get Involved reusable components section

![image](https://github.com/user-attachments/assets/b8384559-8af2-4a32-8d25-4480256c08f3)

⬇️

![image](https://github.com/user-attachments/assets/f158c6d9-fb6b-4d50-8943-2e838c493a95)

2. Video sections on landing pages

![image](https://github.com/user-attachments/assets/5cb3c75d-6943-4f24-bc85-2a32ed53edfa)

⬇️

![image](https://github.com/user-attachments/assets/0a8eff7a-57ea-4ce3-805c-c97701498506)

[Preview](https://deploy-preview-293--novu-website.netlify.app/inbox/)