### PR TITLE
fix: use-cases images fix, header link

### DIFF
--- a/src/components/shared/reusable-sections/text-with-picture/text-with-picture.jsx
+++ b/src/components/shared/reusable-sections/text-with-picture/text-with-picture.jsx
@@ -7,19 +7,14 @@ import Heading from 'components/shared/heading';
 
 const TextWithPicture = ({
   className,
+  imageClassName,
   title,
   description,
   image,
-  imageClassName,
   button,
   theme,
 }) => (
-  <section
-    className={clsx(
-      'text-with-picture safe-paddings mt-40 lg:mt-36 md:mt-[104px] sm:mt-14',
-      className
-    )}
-  >
+  <section className="text-with-picture safe-paddings mt-40 lg:mt-36 md:mt-[104px] sm:mt-14">
     <div className="container-lg px-8 md:px-7 sm:px-4">
       <div
         className={clsx(
@@ -28,12 +23,16 @@ const TextWithPicture = ({
         )}
       >
         <div
-          className={clsx('relative z-10 sm:order-first sm:mb-6 sm:pl-0 sm:pr-0 sm:text-center', {
-            'mb-12 max-w-[704px] text-center lg:mb-10 md:mb-8 md:max-w-lg sm:mb-6':
-              theme === 'imageFullWidth',
-            'order-last pl-24 lg:pl-16 md:pl-8': theme === 'imageLeft',
-            'order-first pr-24 lg:pr-16 md:pr-8': theme === 'imageRight',
-          })}
+          className={clsx(
+            'relative z-10 sm:order-first sm:mb-6 sm:px-0 sm:text-center',
+            {
+              'mb-12 max-w-[704px] text-center lg:mb-10 md:mb-8 md:max-w-lg sm:mb-6':
+                theme === 'imageFullWidth',
+              'order-last pl-24 lg:pl-16 md:pl-8': theme === 'imageLeft',
+              'order-first pr-24 lg:pr-16 md:pr-8': theme === 'imageRight',
+            },
+            className
+          )}
         >
           <Heading
             className="font-medium leading-denser tracking-snug lg:text-5xl md:text-[32px] sm:text-3xl"
@@ -63,7 +62,7 @@ const TextWithPicture = ({
             </Button>
           )}
         </div>
-        <div className={clsx('overflow-hidden rounded-lg', imageClassName)}>{image}</div>
+        <div className={imageClassName}>{image}</div>
         {button && theme === 'imageFullWidth' && (
           <Button
             className="mt-9 md:mt-8 sm:mt-6"
@@ -84,24 +83,23 @@ const TextWithPicture = ({
 
 TextWithPicture.propTypes = {
   className: PropTypes.string,
+  imageClassName: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   image: PropTypes.node.isRequired,
-  imageClassName: PropTypes.string,
   button: PropTypes.shape({
     label: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
     rel: PropTypes.string,
     target: PropTypes.string,
-    hiddenLabel: PropTypes.string,
   }),
   theme: PropTypes.oneOf(['imageLeft', 'imageRight', 'imageFullWidth']),
 };
 
 TextWithPicture.defaultProps = {
-  className: '',
   button: null,
   theme: 'imageLeft',
+  className: '',
   imageClassName: '',
 };
 

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -130,7 +130,7 @@ const MENUS = {
             title: 'Use Cases',
             description: "How you'll use Novu",
             icon: UseCasesIcon,
-            to: 'usecases/?utm_campaign=ws_nav',
+            to: '/usecases/?utm_campaign=ws_nav',
           },
         ],
       },

--- a/src/pages/framework.jsx
+++ b/src/pages/framework.jsx
@@ -306,9 +306,9 @@ const FrameworkPage = () => (
     <TextWithPicture
       title="Complete workflow control"
       description="Development teams have complete control over customizations and workflows, and what other teams can safely edit or update."
-      className="mt-[405px] lg:mt-[280px] md:mt-[250px] sm:mt-[110px]"
+      className="mt-[238px] lg:mt-[100px] md:mt-[88px] sm:mt-[60px]"
       image={
-        <div className="absolute left-1/2 top-1/2 -translate-x-[53%] -translate-y-[59%] lg:-translate-x-[54%] lg:-translate-y-[57%] md:-translate-x-[56%] md:-translate-y-[52%] sm:top-0 sm:-translate-x-[55%] sm:-translate-y-[156px]">
+        <div className="absolute left-1/2 top-1/2 -translate-x-[53%] -translate-y-[48%] xl:-translate-y-[45%] lg:-translate-x-[54%] lg:-translate-y-[50%] md:-translate-x-[56%] md:-translate-y-[52%] sm:top-0 sm:-translate-x-[55%] sm:-translate-y-[156px]">
           <StaticImage
             className="pointer-events-none w-[1198px] lg:w-[1012px] md:w-[816px] sm:w-[700px]"
             src="../images/pages/framework/workflow.png"
@@ -329,9 +329,9 @@ const FrameworkPage = () => (
     <TextWithPicture
       title="Self service access for non-technical teams"
       description="Product teams can safely make targeted content updates without breaking workflow or business logic. Reduce developer interrupts for things like content updates."
-      className="mt-[540px] lg:mt-[282px] md:mt-[250px] sm:mt-[410px]"
+      className="mt-[380px] lg:mt-[184px] md:mt-[110px] sm:mt-[410px]"
       image={
-        <div className="absolute left-1/2 top-1/2 -translate-x-[60%] -translate-y-[61%] xl:-translate-x-[53%] lg:-translate-x-[55%] lg:-translate-y-[65%] md:-translate-x-[52%] md:-translate-y-[63%] sm:top-0 sm:-translate-y-[176px] sm-xs:-translate-y-[156px]">
+        <div className="absolute left-1/2 top-1/2 -translate-x-[60%] -translate-y-[47%] xl:-translate-x-[53%] lg:-translate-x-[55%] lg:-translate-y-[47%] md:-translate-x-[52%] md:-translate-y-[52%] sm:top-0 sm:-translate-y-[176px] sm-xs:-translate-y-[156px]">
           <StaticImage
             className="pointer-events-none w-[1128px] xl:w-[850px] lg:w-[600px] md:w-[506px] sm-xs:w-[440px]"
             src="../images/pages/framework/self-service.png"
@@ -351,9 +351,9 @@ const FrameworkPage = () => (
     <TextWithPicture
       title="Reuse existing content and providers"
       description="Integrate with legacy systems and platforms, and easily include content from any source and in any format."
-      className="mt-[654px] lg:mt-[282px] md:mt-[250px] sm:mt-[324px]"
+      className="mt-[414px] lg:mt-[184px] md:mt-[88px] sm:mt-[280px]"
       image={
-        <div className="absolute left-1/2 top-1/2 -translate-x-[44%] -translate-y-[66%] lg:-translate-x-[43%] lg:-translate-y-[65%] md:-translate-x-[46%] sm:top-0 sm:-translate-y-[142px] sm-xs:-translate-y-[126px]">
+        <div className="absolute left-1/2 top-1/2 -translate-x-[44%] -translate-y-[40%] lg:-translate-x-[43%] lg:-translate-y-[45%] md:-translate-x-[46%] md:-translate-y-[52%] sm:top-0 sm:-translate-y-[142px] sm-xs:-translate-y-[126px]">
           <StaticImage
             className="pointer-events-none w-[1024px] lg:w-[720px] md:w-[580px] sm:w-[600px] sm-xs:w-[540px]"
             src="../images/pages/framework/reuse.png"
@@ -374,9 +374,9 @@ const FrameworkPage = () => (
     <TextWithPicture
       title="Locally run, cloud powered"
       description="Your local Novu Framework integrates with Novu Cloud to power delivery, management, and analytics."
-      className="mb-[100px] mt-[553px] lg:mt-[282px] md:mt-[250px] sm:mb-[220px] sm:mt-[310px]"
+      className="mb-[100px] mt-[402px] lg:mt-[184px] md:mb-[50px] md:mt-[88px] sm:mb-[220px] sm:mt-[260px]"
       image={
-        <div className="absolute left-1/2 top-1/2 -translate-x-[42%] -translate-y-[64%] xl:-translate-x-[38%] lg:-translate-x-[39%] lg:-translate-y-[65%] md:-translate-x-[38%] sm:top-0 sm:-translate-y-[118px] sm-xs:-translate-y-[96px]">
+        <div className="absolute left-1/2 top-1/2 -translate-x-[42%] -translate-y-[51%] xl:-translate-x-[38%] xl:-translate-y-[45%] lg:-translate-x-[39%] lg:-translate-y-[56%] md:-translate-x-[38%] sm:top-0 sm:-translate-y-[288px]">
           <StaticImage
             className="pointer-events-none w-[1081px] xl:w-[850px] lg:w-[620px] md:w-[480px] sm-xs:w-[440px]"
             src="../images/pages/framework/cloud.png"
@@ -394,7 +394,7 @@ const FrameworkPage = () => (
       }}
     />
     <CtaWithForm
-      className="mb-[147px] mt-[370px] text-center xl:mt-[280px] sm:mt-[320px]"
+      className="mb-[147px] mt-[190px] text-center xl:mt-[280px] lg:mt-[140px]"
       title="Get started for free"
       description="No credit card required. <br/>You're just five minutes from your first Novu notification."
       leftItem={{

--- a/src/pages/usecases.jsx
+++ b/src/pages/usecases.jsx
@@ -145,7 +145,7 @@ const UseCasesPage = () => (
       theme="imageRight"
     />
     <TextWithPicture
-      contentClassName="py-[248px] md:py-32 sm:pt-0 sm:pb-20"
+      className="py-[288px] md:py-32 sm:pb-20 sm:pt-0"
       title="Centrally manage notification content"
       description="Eliminate the content dance between development and product teams. Developers now empower product teams to safely interact with all of your notifications content, no interrupts needed."
       imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"

--- a/src/pages/usecases.jsx
+++ b/src/pages/usecases.jsx
@@ -35,10 +35,10 @@ const FEATURE_CARDS = [
 const UseCasesPage = () => (
   <Layout mainClassName="reusable-components overflow-hidden pt-16 bg-[#05050B]">
     <TextWithPicture
-      contentClassName="pt-[76px] pb-[100px] md:pt-0 md:pb-16"
+      className="pb-[100px] pt-[76px] md:pb-16 md:pt-0"
       title="Elevate Engagement with Robust Notifications"
       description="Deliver personalized, multi-channel notifications with ease using Novu’s unified platform—empowering teams to create seamless communication experiences that drive user satisfaction and retention."
-      imageWrapperClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
+      imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
       image={
         <div className="absolute left-1/2 top-1/2 h-[791px] w-[1216px] max-w-none -translate-x-1/2 -translate-y-[calc(50%+94px)] lg:h-auto lg:w-[1000px] lg:-translate-x-[calc(50%+50px)] md:w-[700px] md:-translate-y-[calc(50%+76px)] sm:w-[130%] xs:w-[160%]">
           <StaticImage
@@ -77,11 +77,10 @@ const UseCasesPage = () => (
       }}
     />
     <TextWithPicture
-      className="sm:!mt-28"
-      contentClassName="py-52 md:py-40 sm:pt-0 sm:pb-20"
+      className="py-52 md:py-40 sm:!mt-28 sm:pb-20 sm:pt-0"
       title="Multi-channel notifications"
       description="Expand your reach by adding more channels ensuring users receive critical information on time, and through their preferred channel."
-      imageWrapperClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
+      imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
       image={
         <div className="absolute left-1/2 top-1/2 h-[1205px] w-[1354px] max-w-none -translate-x-[calc(50%+4px)] -translate-y-[calc(50%+42px)] md:h-auto md:w-[1000px] sm:w-[130%] xs:w-[150%]">
           <StaticImage
@@ -101,11 +100,10 @@ const UseCasesPage = () => (
       theme="imageRight"
     />
     <TextWithPicture
-      className="relative z-10"
-      contentClassName="py-[184px] md:py-32 sm:pt-0 sm:pb-28 xs:pb-36"
+      className="relative z-10 py-[184px] md:py-32 sm:pb-28 sm:pt-0 xs:pb-36"
       title="Add notifications to your application"
       description="Notifications are the best way to keep your users and customers informed through relevant, timely updates, and adding them to your app or website is easier than you think."
-      imageWrapperClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
+      imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px] z-10"
       image={
         <div className="absolute left-1/2 top-1/2 h-[1007px] w-[1107px] max-w-none -translate-x-[calc(50%-73px)] -translate-y-[calc(50%+156px)] md:h-auto md:w-[1000px] sm:w-[130%] xs:w-[150%]">
           <StaticImage
@@ -124,10 +122,10 @@ const UseCasesPage = () => (
       }}
     />
     <TextWithPicture
-      contentClassName="py-20 md:py-10 sm:pt-0 sm:pb-20 xs:pb-32"
+      className="py-20 md:py-10 sm:pb-20 sm:pt-0 xs:pb-32"
       title="Unified notification management"
       description="Reduce your app’s complexity by designing, managing, and triggering notifications from a central platform instead of multiple different tools."
-      imageWrapperClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
+      imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
       image={
         <div className="absolute left-1/2 top-1/2 h-[915px] w-[919px] max-w-none -translate-x-[calc(50%+19px)] -translate-y-[calc(50%+111px)] md:h-auto md:w-[800px] md:-translate-x-[calc(50%+49px)] sm:w-[130%] xs:w-[150%]">
           <StaticImage
@@ -150,9 +148,9 @@ const UseCasesPage = () => (
       contentClassName="py-[248px] md:py-32 sm:pt-0 sm:pb-20"
       title="Centrally manage notification content"
       description="Eliminate the content dance between development and product teams. Developers now empower product teams to safely interact with all of your notifications content, no interrupts needed."
-      imageWrapperClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
+      imageClassName="relative w-full h-full sm:h-[300px] xs:h-[200px]"
       image={
-        <div className="absolute left-1/2 top-1/2 h-[1054px] w-[1343px] max-w-none -translate-x-1/2 -translate-y-[calc(50%+56px)] xl:h-auto xl:w-[1000px] xl:-translate-x-[calc(50%-60px)] lg:w-[850px] lg:-translate-x-[calc(50%-55px)] md:w-[700px] sm:w-[130%] xs:w-[150%]">
+        <div className="absolute left-1/2 top-1/2 h-[1054px] w-[1343px] max-w-none -translate-x-1/2 -translate-y-[calc(50%+56px)] xl:h-auto xl:w-[1000px] xl:-translate-x-[calc(50%-60px)] lg:w-[850px] lg:-translate-x-[calc(50%-55px)] md:w-[700px] sm:w-[130%] sm:-translate-y-[calc(50%-20px)] sm-xs:w-[150%]">
           <StaticImage
             className="size-full object-cover"
             src="../images/pages/usecases/index/content/illustration.png"
@@ -170,7 +168,7 @@ const UseCasesPage = () => (
       }}
     />
     <CtaWithForm
-      className="mb-52"
+      className="mb-52 sm:mt-[224px] sm-xs:mt-[164px]"
       title="We’re ready for your requirements..."
       description="Whatever your use case, Novu is ready. Start for free, no credit card required."
       leftItem={{


### PR DESCRIPTION
**Description**

This PR brings fixes for 
- images on Use-cases page;
- link for header to use-cases page;

**Steps to test**

1. Open [the page](https://deploy-preview-315--novu-website.netlify.app/usecases)
2. Confirm that everything looks and works as expected


**Screenshots**

<details>
<summary>Header link issue</summary>
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/b7134f43-9fff-4dfa-9879-8015c225557f" />
</details>

<details>
<summary>Use cases images issue</summary>
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/3a47eefa-9484-4f5f-8dac-c537d91efd85" />
</details>

