### PR TITLE
feat: change inbox section heading on home page

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -239,7 +239,7 @@ const HomePage = () => (
     />
     <Inbox
       sectionOffsets="mt-[250px] sm:mt-20"
-      title="Some header that includes up to three lines of engaging text"
+      title="<Inbox /> Component"
       description="Enable in-app notifications in your app or website with a pre-built and customizable components, available in popular frameworks."
       button={{
         label: 'Learn more',


### PR DESCRIPTION
This PR brings new heading for Inbox section on the main Page

[Preview](https://deploy-preview-326--novu-website.netlify.app/)

Before
<img width="900" alt="image" src="https://github.com/user-attachments/assets/88bc520b-1ce0-4972-88ae-dca861aaf522" />

After
<img width="900" alt="image" src="https://github.com/user-attachments/assets/f842fc84-9e08-40d8-80a2-99ae3eba5ef3" />
