### PR TITLE
Fix: Removed incorrectly rendered <br /> tag from the page.

### DIFF
--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -79,7 +79,7 @@ const PRICING_PLANS = [
       theme: 'gray-outline',
       link: 'https://novu.co/contact-us/?utm_campaign=ws_pricing',
     },
-    description: 'Unlimited power.<br />Built for scale.',
+    description: 'Unlimited power. Built for scale.',
     advantagesHeading: 'Everything in Team, plus...',
     advantages: [
       '5M events/month included',


### PR DESCRIPTION
Under the Enterprise card on the pricing page, there’s a visible "<br />" tag.