### PR TITLE
fix: scroll-to-top issue on route change

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,18 +11,26 @@ export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPo
     return false;
   }
 
-  window.history.scrollRestoration = 'manual';
-  const currentPosition = getSavedScrollPosition(location, location.key);
-
-  if (!currentPosition) {
-    window.scrollTo(0, 0);
-  } else {
-    window.setTimeout(() => {
-      window.requestAnimationFrame(() => {
-        window.scrollTo(...currentPosition);
-      });
-    }, 0);
+  if (location.hash) {
+    window.history.scrollRestoration = 'auto';
+    return true;
   }
+
+  window.history.scrollRestoration = 'manual';
+
+  const currentPosition = getSavedScrollPosition(location, location.key);
+  const top = currentPosition ? currentPosition[1] : 0;
+  const left = currentPosition ? currentPosition[0] : 0;
+
+  window.setTimeout(() => {
+    window.requestAnimationFrame(() => {
+      try {
+        window.scrollTo({ top, left, behavior: 'instant' });
+      } catch (e) {
+        window.scrollTo(left, top);
+      }
+    });
+  }, 0);
 
   return false;
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -16,18 +16,19 @@ export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPo
     return true;
   }
 
+  // Fix for Gatsby 5 issue with scroll-behavior - [issue](https://github.com/gatsbyjs/gatsby/issues/38201)
+
   window.history.scrollRestoration = 'manual';
 
   const currentPosition = getSavedScrollPosition(location, location.key);
   const top = currentPosition ? currentPosition[1] : 0;
-  const left = currentPosition ? currentPosition[0] : 0;
 
   window.setTimeout(() => {
     window.requestAnimationFrame(() => {
       try {
-        window.scrollTo({ top, left, behavior: 'instant' });
+        window.scrollTo({ top, behavior: 'instant' });
       } catch (e) {
-        window.scrollTo(left, top);
+        window.scrollTo(top);
       }
     });
   }, 0);

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,10 +6,23 @@ export const onRouteUpdate = () => {
   }
 };
 
-export const shouldUpdateScroll = ({ routerProps: { location } }) => {
+export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPosition }) => {
   if (location.state && location.state.preventScroll === true) {
     return false;
   }
 
-  return true;
+  window.history.scrollRestoration = 'manual';
+  const currentPosition = getSavedScrollPosition(location, location.key);
+
+  if (!currentPosition) {
+    window.scrollTo(0, 0);
+  } else {
+    window.setTimeout(() => {
+      window.requestAnimationFrame(() => {
+        window.scrollTo(...currentPosition);
+      });
+    }, 0);
+  }
+
+  return false;
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -16,7 +16,7 @@ export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPo
     return true;
   }
 
-  // Fix for Gatsby 5 issue with scroll-behavior - [issue](https://github.com/gatsbyjs/gatsby/issues/38201)
+  // Fix for Gatsby 5 issue with scroll-behavior - https://github.com/gatsbyjs/gatsby/issues/38201
 
   window.history.scrollRestoration = 'manual';
 


### PR DESCRIPTION
**Describe what changes this pull request brings**

Fix scroll-to-top issue on route change in Gatsby

Addresses an issue where `scroll-behavior: smooth` causes the scroll-to-top action to be interrupted during rehydration, due to layout shifts from dynamically loaded DOM elements

**Steps to check:**

1. Open preview: [Home page](https://deploy-preview-341--novu-website.netlify.app/), [URL with hash](https://deploy-preview-341--novu-website.netlify.app/landing/get-started/#video)
2. Make sure that everything looks and works as expected