### PR TITLE
feat: add proxy for changelog to new website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,12 @@
   force = true
 
 [[redirects]]
+  from = "/api/*"
+  to = "https://novu-next.vercel.app/api/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/studio"
   to = "https://novu-next.vercel.app/studio"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,19 +28,19 @@
   force = true
 
 [[redirects]]
-  from = "/studio"
-  to = "https://novu-next.vercel.app/studio"
+  from = "/images/*"
+  to = "https://novu-next.vercel.app/images/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/changelog"
-  to = "https://novu-next.vercel.app/changelog"
+  from = "/studio/:splat"
+  to = "https://novu-next.vercel.app/studio/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/changelog/*"
+  from = "/changelog/:splat"
   to = "https://novu-next.vercel.app/changelog/:splat"
   status = 200
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,19 +28,25 @@
   force = true
 
 [[redirects]]
-  from = "/images/*"
-  to = "https://novu-next.vercel.app/images/:splat"
+  from = "/studio"
+  to = "https://novu-next.vercel.app/studio"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/studio/:splat"
+  from = "/studio/*"
   to = "https://novu-next.vercel.app/studio/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/changelog/:splat"
+  from = "/changelog"
+  to = "https://novu-next.vercel.app/changelog"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/changelog/*"
   to = "https://novu-next.vercel.app/changelog/:splat"
   status = 200
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,12 @@
   force = true
 
 [[redirects]]
+  from = "/studio"
+  to = "https://novu-next.vercel.app/studio"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/changelog"
   to = "https://novu-next.vercel.app/changelog"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,3 +18,17 @@
 #   to = "https://inbox.novu.co/inbox/playground/api/trigger"
 #   status = 200
 #   force = true
+
+# Changelog
+
+[[redirects]]
+  from = "/changelog"
+  to = "https://novu-next.vercel.app/changelog"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/changelog/*"
+  to = "https://novu-next.vercel.app/changelog/:splat"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,13 @@
 #   status = 200
 #   force = true
 
-# Changelog
+# New website
+
+[[redirects]]
+  from = "/_next/*"
+  to = "https://novu-next.vercel.app/_next/:splat"
+  status = 200
+  force = true
 
 [[redirects]]
   from = "/changelog"

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,6 +34,12 @@
   force = true
 
 [[redirects]]
+  from = "/favicon/*"
+  to = "https://novu-next.vercel.app/favicon/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/studio"
   to = "https://novu-next.vercel.app/studio"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,42 +23,42 @@
 
 [[redirects]]
   from = "/_next/*"
-  to = "https://novu-next.vercel.app/_next/:splat"
+  to = "https://website-new-novuhq.vercel.app/_next/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/api/*"
-  to = "https://novu-next.vercel.app/api/:splat"
+  to = "https://website-new-novuhq.vercel.app/api/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/favicon/*"
-  to = "https://novu-next.vercel.app/favicon/:splat"
+  to = "https://website-new-novuhq.vercel.app/favicon/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/studio"
-  to = "https://novu-next.vercel.app/studio"
+  to = "https://website-new-novuhq.vercel.app/studio"
   status = 200
   force = true
 
 [[redirects]]
   from = "/studio/*"
-  to = "https://novu-next.vercel.app/studio/:splat"
+  to = "https://website-new-novuhq.vercel.app/studio/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/changelog"
-  to = "https://novu-next.vercel.app/changelog"
+  to = "https://website-new-novuhq.vercel.app/changelog"
   status = 200
   force = true
 
 [[redirects]]
   from = "/changelog/*"
-  to = "https://novu-next.vercel.app/changelog/:splat"
+  to = "https://website-new-novuhq.vercel.app/changelog/:splat"
   status = 200
   force = true

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -55,6 +55,11 @@ export default {
     target: '_self',
   },
 
+  // New website
+  changeLog: {
+    to: '/changelog',
+  },
+
   // Dashboard
   dashboard: {
     to: 'https://dashboard.novu.co',
@@ -75,10 +80,6 @@ export default {
   // Other pages
   roadmapPage: {
     to: 'https://roadmap.novu.co',
-    target: '_blank',
-  },
-  changeLog: {
-    to: 'https://roadmap.novu.co/changelog',
     target: '_blank',
   },
   handbook: {

--- a/src/hooks/use-header-data.js
+++ b/src/hooks/use-header-data.js
@@ -55,9 +55,10 @@ export default function useHeaderData() {
       description: changelog?.notes
         ? getChangelogContent(changelog.notes)
         : DEFAULT_STATE.changelog.description,
-      url: changelog?.id
-        ? `https://roadmap.novu.co/changelog/${changelog.id}`
-        : DEFAULT_STATE.changelog.url,
+      url:
+        // changelog?.id
+        // ? `${LINKS.changeLog.to}/${changelog.id}` :
+        DEFAULT_STATE.changelog.url,
       image: changelog?.imageUrl || DEFAULT_STATE.changelog.image,
     },
     post: {


### PR DESCRIPTION
This PR brings a proxy for changelog to new website

Preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changelog is now available within the site at /changelog, replacing the previous external link for a smoother, consistent experience.
  * Added redirects to route specific site paths to the new website, ensuring seamless navigation for assets, APIs and the changelog; existing routes remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->