### PR TITLE
fix: update text-with-picture component to disable pointer events on image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,6 +3104,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/components/shared/reusable-sections/text-with-picture/text-with-picture.jsx
+++ b/src/components/shared/reusable-sections/text-with-picture/text-with-picture.jsx
@@ -63,7 +63,7 @@ const TextWithPicture = ({
             </Button>
           )}
         </div>
-        <div className={imageClassName}>{image}</div>
+        <div className={clsx(imageClassName, 'pointer-events-none')}>{image}</div>
         {button && theme === 'imageFullWidth' && (
           <Button
             className="mt-9 md:mt-8 sm:mt-6"


### PR DESCRIPTION
This pull-request brings small fix to prevent image overlapping in the TextWithPicture component

Steps to check:

1. Open page https://deploy-preview-360--novu-website.netlify.app/usecases/ in Safari browser
2. Find section "Add notifications to your application"
3. Make sure that you can press the button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made images in the Text with Picture section non-interactive to prevent accidental clicks or taps.
  * Improves usability on touch devices by avoiding unintended image interactions during scroll.
  * No visual changes; existing styles and layout remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->