### PR TITLE
fix: disable pointer events on background image in FeatureCards component

### DIFF
--- a/src/components/shared/reusable-sections/feature-cards/feature-cards.jsx
+++ b/src/components/shared/reusable-sections/feature-cards/feature-cards.jsx
@@ -13,7 +13,7 @@ const FeatureCards = ({ className, title, description, cards, columns = 3 }) => 
       className
     )}
   >
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+    <div className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
       <StaticImage src="./images/bg-blur.svg" alt="" loading="" width={1652} height={928} />
     </div>
     <div


### PR DESCRIPTION
This pull request brings small fix to prevent background image overlapping in the FeatureCards component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a decorative background in feature cards blocked clicks and taps on underlying content. Users can now interact with links, buttons, and other controls as expected.
  * Improves usability on touch devices and reduces accidental non-responsive areas.

* **Style**
  * Adjusted background behavior to ignore pointer interactions while preserving the visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->