### PR TITLE
fix: remove isNew tag from footer links

### DIFF
--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -110,7 +110,7 @@ const MENUS = {
           },
           { label: 'Workflows', href: LINKS.docsWorkflow.to, isNew: false },
           { label: 'Framework', href: LINKS.framework.to, isNew: false },
-          { label: 'Digest', href: LINKS.digest.to, isNew: true },
+          { label: 'Digest', href: LINKS.digest.to, isNew: false },
           {
             label: 'Content Management',
             href: LINKS.docsContentManagement.to,
@@ -126,7 +126,7 @@ const MENUS = {
       {
         title: 'Resources',
         items: [
-          { label: 'Documentation', href: LINKS.docs.to, isNew: true },
+          { label: 'Documentation', href: LINKS.docs.to, isNew: false },
           { label: 'Blog', href: LINKS.blog.to, isNew: false },
           { label: 'Use Cases', href: LINKS.useCases.to, isNew: false },
           { label: 'Changelog', href: LINKS.changeLog.to, isNew: false },


### PR DESCRIPTION
**Describe what changes this pull request brings**

All isNew tags set as false on footer links

**Steps to check:**

1. Open [preview](https://deploy-preview-368--novu-website.netlify.app)
2. Make sure that everything looks and works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Removed the “New” badges from Digest (Footer > Product) and Documentation (Footer > Resources) to reflect their established status.
  - Visual presentation updated only; navigation structure and link destinations remain unchanged.
  - Improves clarity and reduces visual noise in the footer for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->