### PR TITLE
fix: proxy for integration-icons

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,12 @@
   force = true
 
 [[redirects]]
+  from = "/images/integration-icons/*"
+  to = "https://website-new-murex.vercel.app/images/integration-icons/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/og-images/*"
   to = "https://website-new-murex.vercel.app/og-images/:splat"
   status = 200


### PR DESCRIPTION
**Summary**

Add proxy for integration icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated redirect configuration to serve integration icon assets from an external service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->