### PR TITLE
fix: forward UTM params from landing pages to signup links

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,7 +6,15 @@ const SIGNUP_HOST = 'dashboard.novu.co';
 function getStoredUtmParams() {
   try {
     const stored = sessionStorage.getItem('novu_utm_params');
-    return stored ? JSON.parse(stored) : {};
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      UTM_PARAMS.flatMap((key) => {
+        const value = parsed[key];
+        return typeof value === 'string' && value ? [[key, value]] : [];
+      })
+    );
   } catch {
     return {};
   }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,9 +1,60 @@
 import './src/styles/main.css';
 
+const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid', 'ttclid', 'wbraid'];
+const SIGNUP_HOST = 'dashboard.novu.co';
+
+function getStoredUtmParams() {
+  try {
+    const stored = sessionStorage.getItem('novu_utm_params');
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function captureUtmParams() {
+  const params = new URLSearchParams(window.location.search);
+  const utms = {};
+  UTM_PARAMS.forEach((key) => {
+    const value = params.get(key);
+    if (value) utms[key] = value;
+  });
+
+  if (Object.keys(utms).length > 0) {
+    try {
+      sessionStorage.setItem('novu_utm_params', JSON.stringify(utms));
+    } catch {
+      // sessionStorage unavailable
+    }
+  }
+}
+
+function forwardUtmToSignupLinks() {
+  const utms = getStoredUtmParams();
+  if (Object.keys(utms).length === 0) return;
+
+  document.querySelectorAll(`a[href*="${SIGNUP_HOST}"]`).forEach((link) => {
+    try {
+      const url = new URL(link.href);
+      Object.entries(utms).forEach(([key, value]) => {
+        if (!url.searchParams.has(key)) {
+          url.searchParams.set(key, value);
+        }
+      });
+      link.href = url.toString();
+    } catch {
+      // skip malformed URLs
+    }
+  });
+}
+
 export const onRouteUpdate = () => {
   if (process.env.NODE_ENV === 'production' && typeof window.plausible !== 'undefined') {
     window.plausible('pageview');
   }
+
+  captureUtmParams();
+  requestAnimationFrame(forwardUtmToSignupLinks);
 };
 
 export const shouldUpdateScroll = ({ routerProps: { location }, getSavedScrollPosition }) => {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -22,7 +22,9 @@ function captureUtmParams() {
 
   if (Object.keys(utms).length > 0) {
     try {
-      sessionStorage.setItem('novu_utm_params', JSON.stringify(utms));
+      const existing = getStoredUtmParams();
+      const merged = { ...existing, ...utms };
+      sessionStorage.setItem('novu_utm_params', JSON.stringify(merged));
     } catch {
       // sessionStorage unavailable
     }
@@ -33,9 +35,10 @@ function forwardUtmToSignupLinks() {
   const utms = getStoredUtmParams();
   if (Object.keys(utms).length === 0) return;
 
-  document.querySelectorAll(`a[href*="${SIGNUP_HOST}"]`).forEach((link) => {
+  document.querySelectorAll('a[href]').forEach((link) => {
     try {
       const url = new URL(link.href);
+      if (url.hostname !== SIGNUP_HOST) return;
       Object.entries(utms).forEach(([key, value]) => {
         if (!url.searchParams.has(key)) {
           url.searchParams.set(key, value);


### PR DESCRIPTION
## Summary

- UTM parameters from paid campaigns are lost when users click signup CTAs because links to `dashboard.novu.co` are static with no query params
- This causes ~65% of signup page traffic to have zero attribution in Mixpanel
- Stores UTM params (`utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `gclid`, `fbclid`, `ttclid`, `wbraid`) in `sessionStorage` on landing
- Appends them to all `dashboard.novu.co` links on every page navigation
- Preserves any existing hardcoded `utm_campaign` values on individual links (e.g. pricing page CTAs)

## How it works

1. When a user lands on any page with UTMs (e.g. from a Google Ad), `captureUtmParams()` saves them to `sessionStorage`
2. On every route change, `forwardUtmToSignupLinks()` finds all `<a>` tags pointing to `dashboard.novu.co` and appends the stored UTMs
3. Existing query params on links are preserved (won't overwrite hardcoded `utm_campaign` values)

## Context

- Paid campaigns (Google Ads CPC/display) drive 11,000+ marketing page visits/month but only ~300 are tracked through to signup
- Root cause: signup CTAs are static `href="https://dashboard.novu.co/auth/sign-up"` with no UTM forwarding
- Mixpanel user properties (`initial_utm_*`) already exist to track attribution -- they just need the data
- Linear: NV-7343

## Test plan

- [ ] Visit `novu.co/?utm_source=test&utm_medium=cpc&utm_campaign=test-campaign`
- [ ] Click any "Sign Up" or "Get Started" CTA
- [ ] Verify the destination URL includes the UTM params
- [ ] Navigate to pricing page and verify pricing CTAs have both their hardcoded `utm_campaign` AND the forwarded `utm_source`/`utm_medium`
- [ ] Verify sessionStorage persists UTMs across page navigations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign and marketing tracking parameters (e.g., UTM/GCLID) are now automatically captured, persisted across navigation, and appended to links that lead to the dashboard so referral context is preserved.
* **Bug Fixes**
  * Improved resilience: storage and URL parsing errors are handled safely to avoid impacting analytics or navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->