### PR TITLE
fix: update package-lock and adjust image dimensions in usecases page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12635,25 +12635,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",

--- a/src/data/pages/usecases/index.jsx
+++ b/src/data/pages/usecases/index.jsx
@@ -116,7 +116,7 @@ const IN_APP_NOTIFICATIONS = {
     <div
       className={clsx(
         imageSharedClassName,
-        'h-[1007px] w-[1107px] -translate-x-[calc(50%-73px)] -translate-y-[calc(50%+156px)] md:h-auto md:w-[1000px] sm:w-[130%] xs:w-[150%]'
+        'h-[1007px] w-[1106px] -translate-x-[calc(50%-73px)] -translate-y-[calc(50%+156px)] md:h-auto md:w-[1000px] sm:w-[130%] xs:w-[150%]'
       )}
     >
       <StaticImage
@@ -124,7 +124,7 @@ const IN_APP_NOTIFICATIONS = {
         src="../../../images/pages/usecases/index/application/illustration.png"
         alt="Add notifications to your application"
         loading="lazy"
-        width={1107}
+        width={1106}
         height={1007}
       />
     </div>


### PR DESCRIPTION
This PR brings fixes for blurry image on usecase page

[Preview](https://deploy-preview-410--novu-website.netlify.app/usecases/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted illustration sizing in the in-app notifications section for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->