### PR TITLE
chore(web): add pnpm minimum-release-age of 3 days (fixes MRK-1722)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=4320


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a top-level `.npmrc` to set pnpm's [`minimum-release-age`](https://pnpm.io/settings#minimumreleaseage) to **3 days (4320 minutes)**.

```
minimum-release-age=4320
```

## Why

This is a supply-chain hardening measure. With `minimum-release-age` set, pnpm will refuse to install package versions that have been published less than the configured age ago, mitigating risk from compromised or malicious package releases that are typically caught and yanked within the first few days.

## Notes

- The unit for `minimum-release-age` is **minutes**: `3 * 24 * 60 = 4320`.
- This is a pnpm-only setting; npm ignores it. The repo currently uses npm, but the setting is harmless to npm-based workflows and will take effect for any pnpm install (local, CI, or future migration).
- No code or dependency changes; only a single new config file.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778560010098619?thread_ts=1778560010.098619&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-be472c86-e827-5e11-a67b-1fb652119f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be472c86-e827-5e11-a67b-1fb652119f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

