### PR TITLE
fix(MRK-1744): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,24 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linting
+        run: npm run lint


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `novuhq/website` repository previously had no GitHub Actions workflows. This change adds a PR lint workflow with all third-party actions pinned to immutable commit SHAs, matching the supply-chain hardening approach used in `novuhq/docs` and `novuhq/novu`.

## Changes

- Add `.github/workflows/pr-checks.yml` with:
  - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (# v4)
  - `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` (# v4)
- Run `npm install` and `npm run lint` on pull requests

## Why

Pinning actions to full commit SHAs prevents supply-chain attacks from mutable version tags (e.g. `@v4` can be retargeted).

## Testing

- Verified `npm run lint` passes locally (warnings only, no errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0ALBUKK3FA/p1779257726142499?thread_ts=1779257726.142499&cid=C0ALBUKK3FA)

<div><a href="https://cursor.com/agents/bc-4b03b632-3f4a-5ce3-9e39-2018f6c16663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b03b632-3f4a-5ce3-9e39-2018f6c16663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

