### PR TITLE
web: add redirect for /agents.md to website-new (fixes MRK-1800)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -191,3 +191,9 @@
   to = "https://website-new-murex.vercel.app/connect/"
   status = 200
   force = true
+
+[[redirects]]
+  from = "/agents.md"
+  to = "https://website-new-murex.vercel.app/agents.md"
+  status = 200
+  force = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Netlify proxy redirect so `https://novu.co/agents.md` serves the agent onboarding document from the new website.

## Changes

- Added a `[[redirects]]` entry in `netlify.toml` for `/agents.md` → `https://website-new-murex.vercel.app/agents.md`
- Uses the same `status = 200` + `force = true` pattern as other website-new routes

## Test plan

- [ ] After deploy, `https://novu.co/agents.md` returns the Novu Agent Onboarding content from website-new
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1004046-ba7c-4a15-923b-600853ba11de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1004046-ba7c-4a15-923b-600853ba11de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

