### PR TITLE
fixes MRK-1808: Proxy robots.txt to website-new

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -97,6 +97,12 @@
   force = true
 
 [[redirects]]
+  from = "/robots.txt"
+  to = "https://website-new-murex.vercel.app/robots.txt"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/next-sitemap*"
   to = "https://website-new-murex.vercel.app/next-sitemap:splat"
   status = 200


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Netlify proxy redirect so `novu.co/robots.txt` is served from website-new, consistent with other migrated assets like `next-sitemap.xml`, `agents.md`, and `llms.txt`.

## Changes

- Add `[[redirects]]` rule in `netlify.toml` for `/robots.txt` → `website-new-murex.vercel.app/robots.txt` (status 200)

## Related

- Companion PR in `novuhq/website-new` generates the robots.txt content with Content-Signal directives
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52e0728b-54eb-4aa6-9e9f-e720750c3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52e0728b-54eb-4aa6-9e9f-e720750c3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

