### PR TITLE
web: add RFC 8288 Link headers for agent discovery (fixes MRK-1796)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -191,6 +191,13 @@ module.exports = {
       resolve: 'gatsby-plugin-netlify',
       options: {
         headers: {
+          '/': [
+            'Link: </.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"',
+          ],
+          '/.well-known/api-catalog': [
+            'Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+            'Cache-Control: public, max-age=3600',
+          ],
           '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
           '/lottie-assets/*': ['Cache-Control: public, max-age=31536000, immutable'],
           '/animations/*': ['Cache-Control: public, max-age=31536000, immutable'],

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,55 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://novu.co/.well-known/api-catalog",
+      "item": [
+        { "href": "https://api.novu.co/v1" },
+        { "href": "https://eu.api.novu.co/v1" },
+        { "href": "https://mcp.novu.co/" }
+      ]
+    },
+    {
+      "anchor": "https://api.novu.co/v1",
+      "service-desc": [
+        {
+          "href": "https://api.novu.co/openapi.json",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/api-reference",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
+      "anchor": "https://eu.api.novu.co/v1",
+      "service-desc": [
+        {
+          "href": "https://eu.api.novu.co/openapi.json",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/api-reference",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
+      "anchor": "https://mcp.novu.co/",
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/platform/build-with-ai/mcp",
+          "type": "text/html"
+        },
+        {
+          "href": "https://novu.co/mcp/",
+          "type": "text/html"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds RFC 8288 `Link` response headers to the novu.co homepage so agents can discover Novu's machine-readable resources per [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727).

## Changes

### Homepage Link headers (`gatsby-config.js`)

The `/` response now includes:

| Target | Relation | Purpose |
|--------|----------|---------|
| `/.well-known/api-catalog` | `api-catalog` | RFC 9727 API catalog |
| `/llms.txt` | `describedby` | Product and doc index for LLMs |
| `/agents.md` | `describedby` | Agent onboarding guide |
| `/auth.md` | `describedby` | Agent credential guide |
| `https://docs.novu.co/api-reference` | `service-doc` | Human-readable API reference |
| `https://api.novu.co/openapi.json` | `service-desc` | Machine-readable OpenAPI spec |

### API catalog (`static/.well-known/api-catalog`)

New linkset document (RFC 9264 / RFC 9727) listing:

- **Novu REST API (US)** — `https://api.novu.co/v1`
- **Novu REST API (EU)** — `https://eu.api.novu.co/v1`
- **Novu MCP Server** — `https://mcp.novu.co/`

Each entry includes `service-desc` (OpenAPI JSON) and `service-doc` links to docs.novu.co.

## Verification

After deploy:

```bash
curl -sI https://novu.co/ | grep -i '^link:'
curl -s https://novu.co/.well-known/api-catalog | jq .
```

Optionally validate with the [isitagentready.com scanner](https://isitagentready.com) — `checks.discoverability.linkHeaders.status` should be `"pass"`.

## References

- [RFC 8288 — Web Linking](https://www.rfc-editor.org/rfc/rfc8288)
- [RFC 9727 — api-catalog Link Relation](https://www.rfc-editor.org/rfc/rfc9727#section-3)
- [Agent Link Headers skill](https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d5de44c-d2b7-4f19-8b87-2cb16a170c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d5de44c-d2b7-4f19-8b87-2cb16a170c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

