### PR TITLE
feat(web): redirect /.well-known/agent-skills to website-new (fixes MRK-1809)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -209,3 +209,9 @@
   to = "https://website-new-murex.vercel.app/llms.txt"
   status = 200
   force = true
+
+[[redirects]]
+  from = "/.well-known/agent-skills/*"
+  to = "https://website-new-murex.vercel.app/.well-known/agent-skills/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a Netlify proxy redirect so `novu.co/.well-known/agent-skills/*` resolves to the agent skills discovery artifacts published in [novuhq/website-new#89](https://github.com/novuhq/website-new/pull/89).

- `/.well-known/agent-skills/*` → `https://website-new-murex.vercel.app/.well-known/agent-skills/:splat` (status `200`, `force = true`)
- Covers `index.json` and all seven `novu-*` skill archives

## Why

The agent skills discovery index now lives on the new website. This redirect keeps `https://novu.co/.well-known/agent-skills/index.json` working for agents scanning `novu.co`, matching the existing pattern used for `agents.md`, `auth.md`, and `llms.txt`.

Linear: MRK-1809
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ffaf570-7428-4aec-9447-28dec318fbff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ffaf570-7428-4aec-9447-28dec318fbff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

