### PR TITLE
web: proxy api-catalog and add homepage Link headers (fixes MRK-1796)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -191,6 +191,9 @@ module.exports = {
       resolve: 'gatsby-plugin-netlify',
       options: {
         headers: {
+          '/': [
+            'Link: </.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"',
+          ],
           '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
           '/lottie-assets/*': ['Cache-Control: public, max-age=31536000, immutable'],
           '/animations/*': ['Cache-Control: public, max-age=31536000, immutable'],

--- a/netlify.toml
+++ b/netlify.toml
@@ -221,8 +221,3 @@
   to = "https://website-new-murex.vercel.app/.well-known/api-catalog"
   status = 200
   force = true
-
-[[headers]]
-  for = "/"
-  [headers.values]
-    Link = '</.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"'

--- a/netlify.toml
+++ b/netlify.toml
@@ -215,3 +215,14 @@
   to = "https://website-new-murex.vercel.app/llms.txt"
   status = 200
   force = true
+
+[[redirects]]
+  from = "/.well-known/api-catalog"
+  to = "https://website-new-murex.vercel.app/.well-known/api-catalog"
+  status = 200
+  force = true
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Link = '</.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Netlify redirects and homepage Link headers so `novu.co` continues to expose agent discovery resources while the canonical content is served from `website-new`.

Supersedes [novuhq/website#426](https://github.com/novuhq/website/pull/426), which added these directly to the Gatsby site.

## Changes

### `netlify.toml`

- **Redirect** `/.well-known/api-catalog` → `website-new` (same pattern as `agents.md`, `llms.txt`, `auth.md`)
- **Link headers** on `/` per RFC 8288 / RFC 9727, pointing to:
  - `/.well-known/api-catalog` (`api-catalog`)
  - `/llms.txt`, `/agents.md`, `/auth.md` (`describedby`)
  - `https://docs.novu.co/api-reference` (`service-doc`)
  - `https://api.novu.co/openapi.json` (`service-desc`)

## Companion PR

Requires [novuhq/website-new#TBD](https://github.com/novuhq/website-new) for the api-catalog file and response headers.

## Verification

After both PRs deploy:

```bash
curl -sI https://novu.co/ | grep -i '^link:'
curl -s https://novu.co/.well-known/api-catalog | jq .
```

## References

- [RFC 8288 — Web Linking](https://www.rfc-editor.org/rfc/rfc8288)
- [RFC 9727 — api-catalog Link Relation](https://www.rfc-editor.org/rfc/rfc9727#section-3)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-294dd69e-2b91-4cbd-b6f4-0fce1ec41094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294dd69e-2b91-4cbd-b6f4-0fce1ec41094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API resource discoverability by exposing documentation and catalog links from the homepage.
  * Configured API catalog endpoint routing for improved access to API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->