### PR TITLE
feat: add redirect for /book-a-demo-connect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -193,6 +193,12 @@
   force = true
 
 [[redirects]]
+  from = "/book-a-demo-connect"
+  to = "https://website-new-novuhq.vercel.app/book-a-demo-connect/"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/connect"
   to = "https://website-new-murex.vercel.app/connect/"
   status = 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configuration to redirect requests from `/book-a-demo-connect` to an external destination with status 200.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->