### PR TITLE
fix(seo): server-render Google Tag Manager site-wide

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,8 +3,9 @@ const React = require('react');
 const SITE_DOMAIN = 'novu.co';
 const PLAUSIBLE_DOMAIN = 'plausible.io';
 const SCRIPT_URI = '/js/script.js';
+const GTM_ID = 'GTM-KXMC4XP2';
 
-exports.onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
+exports.onRenderBody = ({ setHeadComponents, setHtmlAttributes, setPreBodyComponents }) => {
   const headComponents = [
     <script
       key="commonroom-signals"
@@ -76,6 +77,27 @@ exports.onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
         }}
       />
     );
+
+    // Google Tag Manager - server-rendered so the tag is present in the initial
+    // HTML on every page (detectable by Tag Assistant, and fires earlier/more
+    // reliably than a client-side <Script>). Previously lived in seo.jsx.
+    headComponents.push(
+      <script
+        key="gtm-head"
+        dangerouslySetInnerHTML={{
+          __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GTM_ID}');`,
+        }}
+      />
+    );
+
+    setPreBodyComponents([
+      <noscript
+        key="gtm-noscript"
+        dangerouslySetInnerHTML={{
+          __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_ID}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+        }}
+      />,
+    ]);
   }
 
   setHeadComponents(headComponents);

--- a/src/components/shared/seo/seo.jsx
+++ b/src/components/shared/seo/seo.jsx
@@ -94,20 +94,9 @@ const SEO = ({
         />
       )}
 
-      {/** Google Tag Manager */}
-      {process.env.NODE_ENV === 'production' && (
-        <Script
-          dangerouslySetInnerHTML={{
-            __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-              })(window,document,'script','dataLayer','GTM-KXMC4XP2');
-          `,
-          }}
-        />
-      )}
+      {/** Google Tag Manager is now server-rendered in gatsby-ssr.js so the tag
+        is present in the initial HTML on every page (detectable + reliable),
+        instead of being injected client-side here. */}
 
       {process.env.NODE_ENV === 'production' && (
         <Script


### PR DESCRIPTION
## What
Server-render Google Tag Manager (`GTM-KXMC4XP2`) via `gatsby-ssr.js` instead of the client-side `<Script>` in `seo.jsx`.

## Why
GTM was injected **client-side** (Gatsby `<Script>`, post-hydration), so it was **absent from the initial server HTML**. Real users still loaded it, but:
- Google's Tag Assistant / their conversion-setup check can't detect it in the page HTML — this triggered a Google Ads support ticket asking us to "install GTM across the entire site."
- It fires late, which is less reliable for conversion tracking (can miss fast bounces / early events).

`website-new` (Next.js: `/connect`, `/aci`, ...) already renders GTM server-side; this brings the Gatsby site (homepage + most pages) in line.

## Change
- **`gatsby-ssr.js`**: add the GTM head snippet via `setHeadComponents` and the `<noscript>` iframe via `setPreBodyComponents`, production-gated, so it's present in the initial HTML on every page.
- **`seo.jsx`**: remove the now-duplicate client-side GTM block (HubSpot, LinkedIn, CrazyEgg scripts untouched).

Container ID and `NODE_ENV === 'production'` gating are unchanged. Net effect: GTM now loads earlier and is detectable in SSR HTML; no double-firing.

## Test
- `npm run build` then verify `GTM-KXMC4XP2` appears in the built HTML for `/` and other pages (it previously only appeared after client hydration).
- Confirm in Google Tag Assistant that the container loads on the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Google Tag Manager initialization by moving it to server-side rendering, ensuring analytics tracking is present from the initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->