### PR TITLE
feat(analytics): fire attributed demo_booked event on Cal.com bookings

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -64,19 +64,20 @@ function forwardUtmToSignupLinks() {
   });
 }
 
-// Register a single, app-wide listener for successful Cal.com bookings.
-//
-// Why this is needed: Cal.com renders the booking flow inside an app.cal.com
-// iframe and fires its own tracking from *that* origin, so it cannot read the
-// novu.co Google Ads cookie (gclid) and every booking lands as "direct" /
-// unattributed. By listening for Cal.com's `bookingSuccessful` event here, the
-// conversion is pushed to the dataLayer from the parent novu.co context, where
-// GTM (server-rendered) and the Ads conversion linker can attribute it to the
-// originating ad click. One namespace-level listener covers every booking
-// surface and fires exactly once per booking.
+/**
+ * Register a single, app-wide listener for successful Cal.com bookings.
+ *
+ * Why this is needed: Cal.com renders the booking flow inside an app.cal.com
+ * iframe and fires its own tracking from that origin, so it cannot read the
+ * novu.co Google Ads cookie (gclid) and every booking lands as "direct" /
+ * unattributed. By listening for Cal.com's `bookingSuccessful` event here, the
+ * conversion is pushed to the dataLayer from the parent novu.co context, where
+ * GTM (server-rendered) and the Ads conversion linker can attribute it to the
+ * originating ad click. One namespace-level listener covers every booking
+ * surface and fires exactly once per booking.
+ */
 async function initDemoBookingTracking() {
   if (demoBookingTrackingInitialized) return;
-  demoBookingTrackingInitialized = true;
 
   try {
     const { getCalApi } = await import('@calcom/embed-react');
@@ -97,15 +98,22 @@ async function initDemoBookingTracking() {
         });
       },
     });
+
+    // Mark initialized only after the listener is successfully registered, so a
+    // failed attempt (e.g. embed import error) doesn't permanently disable
+    // tracking and can be retried on a later page load.
+    demoBookingTrackingInitialized = true;
   } catch {
     // Cal.com embed unavailable; nothing to track.
   }
 }
 
+/**
+ * Gatsby client-entry hook. Registers the demo-booking listener once, deferred
+ * to idle so loading the Cal embed never competes with first render. A booking
+ * takes many seconds to complete, so the listener is always ready in time.
+ */
 export const onClientEntry = () => {
-  // Defer until idle so loading the Cal embed never competes with first render.
-  // A booking takes many seconds to complete, so the listener is always ready
-  // well before any `bookingSuccessful` fires.
   const start = () => initDemoBookingTracking();
   if (typeof window.requestIdleCallback === 'function') {
     window.requestIdleCallback(start, { timeout: 3000 });

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,6 +3,11 @@ import './src/styles/main.css';
 const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid', 'ttclid', 'wbraid'];
 const SIGNUP_HOST = 'dashboard.novu.co';
 
+// Cal.com embed namespace shared by every booking entry point on the site
+// (pricing scheduling modal, contact-us, and any future ones).
+const CAL_NAMESPACE = 'novu-meeting';
+let demoBookingTrackingInitialized = false;
+
 function getStoredUtmParams() {
   try {
     const stored = sessionStorage.getItem('novu_utm_params');
@@ -58,6 +63,56 @@ function forwardUtmToSignupLinks() {
     }
   });
 }
+
+// Register a single, app-wide listener for successful Cal.com bookings.
+//
+// Why this is needed: Cal.com renders the booking flow inside an app.cal.com
+// iframe and fires its own tracking from *that* origin, so it cannot read the
+// novu.co Google Ads cookie (gclid) and every booking lands as "direct" /
+// unattributed. By listening for Cal.com's `bookingSuccessful` event here, the
+// conversion is pushed to the dataLayer from the parent novu.co context, where
+// GTM (server-rendered) and the Ads conversion linker can attribute it to the
+// originating ad click. One namespace-level listener covers every booking
+// surface and fires exactly once per booking.
+async function initDemoBookingTracking() {
+  if (demoBookingTrackingInitialized) return;
+  demoBookingTrackingInitialized = true;
+
+  try {
+    const { getCalApi } = await import('@calcom/embed-react');
+    const cal = await getCalApi({ namespace: CAL_NAMESPACE });
+
+    cal('on', {
+      action: 'bookingSuccessful',
+      callback: () => {
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+          event: 'demo_booked',
+          demo_booking: {
+            source: 'cal.com',
+            namespace: CAL_NAMESPACE,
+            // UTM/gclid captured on landing, for downstream/offline attribution.
+            ...getStoredUtmParams(),
+          },
+        });
+      },
+    });
+  } catch {
+    // Cal.com embed unavailable; nothing to track.
+  }
+}
+
+export const onClientEntry = () => {
+  // Defer until idle so loading the Cal embed never competes with first render.
+  // A booking takes many seconds to complete, so the listener is always ready
+  // well before any `bookingSuccessful` fires.
+  const start = () => initDemoBookingTracking();
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(start, { timeout: 3000 });
+  } else {
+    window.setTimeout(start, 2000);
+  }
+};
 
 export const onRouteUpdate = () => {
   if (process.env.NODE_ENV === 'production' && typeof window.plausible !== 'undefined') {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,8 +3,6 @@ import './src/styles/main.css';
 const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid', 'ttclid', 'wbraid'];
 const SIGNUP_HOST = 'dashboard.novu.co';
 
-// Cal.com embed namespace shared by every booking entry point on the site
-// (pricing scheduling modal, contact-us, and any future ones).
 const CAL_NAMESPACE = 'novu-meeting';
 let demoBookingTrackingInitialized = false;
 
@@ -64,57 +62,34 @@ function forwardUtmToSignupLinks() {
   });
 }
 
-/**
- * Register a single, app-wide listener for successful Cal.com bookings.
- *
- * Why this is needed: Cal.com renders the booking flow inside an app.cal.com
- * iframe and fires its own tracking from that origin, so it cannot read the
- * novu.co Google Ads cookie (gclid) and every booking lands as "direct" /
- * unattributed. By listening for Cal.com's `bookingSuccessful` event here, the
- * conversion is pushed to the dataLayer from the parent novu.co context, where
- * GTM (server-rendered) and the Ads conversion linker can attribute it to the
- * originating ad click. One namespace-level listener covers every booking
- * surface and fires exactly once per booking.
- */
 async function initDemoBookingTracking() {
   if (demoBookingTrackingInitialized) return;
 
-  try {
-    const { getCalApi } = await import('@calcom/embed-react');
-    const cal = await getCalApi({ namespace: CAL_NAMESPACE });
+  const { getCalApi } = await import('@calcom/embed-react');
+  const cal = await getCalApi({ namespace: CAL_NAMESPACE });
 
-    cal('on', {
-      action: 'bookingSuccessful',
-      callback: () => {
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-          event: 'demo_booked',
-          demo_booking: {
-            source: 'cal.com',
-            namespace: CAL_NAMESPACE,
-            // UTM/gclid captured on landing, for downstream/offline attribution.
-            ...getStoredUtmParams(),
-          },
-        });
-      },
-    });
+  cal('on', {
+    action: 'bookingSuccessful',
+    callback: () => {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'demo_booked',
+        demo_booking: {
+          source: 'cal.com',
+          namespace: CAL_NAMESPACE,
+          ...getStoredUtmParams(),
+        },
+      });
+    },
+  });
 
-    // Mark initialized only after the listener is successfully registered, so a
-    // failed attempt (e.g. embed import error) doesn't permanently disable
-    // tracking and can be retried on a later page load.
-    demoBookingTrackingInitialized = true;
-  } catch {
-    // Cal.com embed unavailable; nothing to track.
-  }
+  demoBookingTrackingInitialized = true;
 }
 
-/**
- * Gatsby client-entry hook. Registers the demo-booking listener once, deferred
- * to idle so loading the Cal embed never competes with first render. A booking
- * takes many seconds to complete, so the listener is always ready in time.
- */
 export const onClientEntry = () => {
-  const start = () => initDemoBookingTracking();
+  const start = () => {
+    initDemoBookingTracking().catch(() => {});
+  };
   if (typeof window.requestIdleCallback === 'function') {
     window.requestIdleCallback(start, { timeout: 3000 });
   } else {


### PR DESCRIPTION
## Problem

Demo bookings (Cal.com) are **not attributed to Google Ads**. Over the last 90 days, **0** of ~50 `booking_confirmation` events came from `google / cpc` — 28 landed as `(direct)`.

Root cause: Cal.com renders the booking flow inside an **`app.cal.com` iframe** and fires its own tracking from that origin. By browser cross-origin rules it cannot read the `novu.co` Google Ads cookie (`_gcl_aw` / `gclid`), so every booking is unattributed and Smart Bidding gets no demo signal. The existing `bookingSuccessful` callbacks in the scheduling modals only **close the modal** — they never fire a conversion.

## Fix

Register **one app-wide listener** in `gatsby-browser.js` (`onClientEntry`) for Cal.com's `bookingSuccessful` event on the shared `novu-meeting` namespace, and push a `demo_booked` event to the `dataLayer` **from the parent novu.co context** — where GTM (now server-rendered, #437) and the Ads conversion linker can attribute it to the originating ad click.

- One namespace-level listener covers **every** booking surface (pricing scheduling modal, `contact-us`, and any future ones) and fires **once** per booking — no per-component patching, no double-count.
- Includes captured UTM/`gclid` (from sessionStorage) in the event payload for downstream/offline use.
- Deferred to idle (`requestIdleCallback`) so loading the Cal embed never competes with first render; a booking takes many seconds, so the listener is always ready in time.
- The components' own `bookingSuccessful` handlers (modal close) are untouched.

## ⚠️ Required follow-up (this PR alone does not complete attribution)

This emits the `demo_booked` dataLayer event. To actually record the Google Ads conversion, a **GTM tag + trigger on `demo_booked`** must be added in the container (`GTM-KXMC4XP2`) → Google Ads Conversion (`AW-16864812041`, new "Demo booked" label). Spec handed to the GTM container owner separately. Recommend also marking it a GA4 key event.

A sibling PR will apply the same listener to `novuhq/website-new` (Next.js pricing modal).

## Testing

- `node --check` passes on the modified file.
- Production-safe: `dataLayer.push` is a no-op where GTM isn't present (dev/staging).
- Manual verification after deploy: open the pricing "Contact us" modal, complete a test booking, confirm a `demo_booked` event appears in `dataLayer` / GTM Preview on the `novu.co` page context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cal.com booking conversion tracking to monitor successful reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->