### PR TITLE
fix(NV-8137): redirect novu.co/docs to docs.novu.co

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,6 +103,20 @@
 #   status = 200
 #   force = true
 
+# Docs redirect
+
+[[redirects]]
+  from = "/docs"
+  to = "https://docs.novu.co/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/*"
+  to = "https://docs.novu.co/:splat"
+  status = 301
+  force = true
+
 # New website
 
 [[redirects]]

--- a/redirects.json
+++ b/redirects.json
@@ -118,5 +118,17 @@
   {
     "fromPath": "/timeline/",
     "toPath": "/"
+  },
+  {
+    "fromPath": "/docs/",
+    "toPath": "https://docs.novu.co/",
+    "statusCode": 301,
+    "force": true
+  },
+  {
+    "fromPath": "/docs/*",
+    "toPath": "https://docs.novu.co/:splat",
+    "statusCode": 301,
+    "force": true
   }
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a permanent redirect from `https://novu.co/docs` to `https://docs.novu.co`, including subpaths.

## Changes

- **`netlify.toml`**: Added 301 redirects for `/docs` and `/docs/*` to `https://docs.novu.co/`
- **`redirects.json`**: Added matching Gatsby redirects for local dev and build consistency

## Test plan

- [ ] Visit `https://novu.co/docs` and confirm redirect to `https://docs.novu.co/`
- [ ] Visit `https://novu.co/docs/platform` and confirm redirect to `https://docs.novu.co/platform`

Fixes NV-8137
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df0d6bd7-f3fd-4bef-8229-9d8b54dba954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df0d6bd7-f3fd-4bef-8229-9d8b54dba954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

