### PR TITLE
web: proxy integrations.json and OpenAPI redirects (fixes MRK-1907)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -192,7 +192,7 @@ module.exports = {
       options: {
         headers: {
           '/': [
-            'Link: </.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"',
+            'Link: </.well-known/api-catalog>; rel="api-catalog", </.well-known/integrations.json>; rel="describedby", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"',
           ],
           '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
           '/lottie-assets/*': ['Cache-Control: public, max-age=31536000, immutable'],

--- a/netlify.toml
+++ b/netlify.toml
@@ -343,6 +343,30 @@
   force = true
 
 [[redirects]]
+  from = "/.well-known/integrations.json"
+  to = "https://website-new-murex.vercel.app/.well-known/integrations.json"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/openapi.json"
+  to = "https://api.novu.co/openapi.json"
+  status = 308
+  force = true
+
+[[redirects]]
+  from = "/openapi.yaml"
+  to = "https://api.novu.co/openapi.yaml"
+  status = 308
+  force = true
+
+[[redirects]]
+  from = "/openapi.yml"
+  to = "https://api.novu.co/openapi.yaml"
+  status = 308
+  force = true
+
+[[redirects]]
   from = "/pricing.md"
   to = "https://website-new-murex.vercel.app/pricing.md"
   status = 200


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires up `novu.co` (Netlify) to serve the integrations manifest and OpenAPI redirects added in [website-new#123](https://github.com/novuhq/website-new/pull/123).

## Changes

- Proxy `/.well-known/integrations.json` to website-new (same pattern as `api-catalog` and `agent-skills`)
- Add 308 redirects for `/openapi.json`, `/openapi.yaml`, and `/openapi.yml` to canonical specs on `https://api.novu.co/`
- Update homepage `Link` header to include `/.well-known/integrations.json` for agent discovery

## Verification

After deploy:

```bash
curl -I https://novu.co/.well-known/integrations.json   # 200
curl -I https://novu.co/openapi.json                  # 308 → api.novu.co
curl -I https://novu.co/                              # Link header includes integrations.json
```

## Related

- Linear: MRK-1907
- website-new: https://github.com/novuhq/website-new/pull/123
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73f8dfc7-fcc9-434b-b393-79299cff51ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73f8dfc7-fcc9-434b-b393-79299cff51ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

