### PR TITLE
fix: proxy careers detail pages to new website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -64,6 +64,7 @@
     "/integrations",
     "/integrations/*",
     "/careers",
+    "/careers/*",
     "/copilot",
     "/copilot/*",
     "/mcp",
@@ -261,6 +262,12 @@
 [[redirects]]
   from = "/careers"
   to = "https://website-new-murex.vercel.app/careers/"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/careers/*"
+  to = "https://website-new-murex.vercel.app/careers/:splat"
   status = 200
   force = true
 


### PR DESCRIPTION
## Summary

- Proxy nested `/careers/*` routes to the new website
- Exclude nested careers routes from the legacy Netlify edge function
- Fix 404 errors on individual careers pages in production

## Validation

[preview](https://deploy-preview-446--novu-website.netlify.app/careers/marketing-operations-lead-3/)