### PR TITLE
fix(web): prevent scroll-to-top overlap with Plain chat fixes NV-8346

### DIFF
--- a/src/components/shared/floating-button/floating-button.jsx
+++ b/src/components/shared/floating-button/floating-button.jsx
@@ -43,9 +43,10 @@ const FloatingButton = ({ isCookieBannerVisible }) => {
         {isVisible && (
           <m.button
             className={clsx(
-              'fixed bottom-5 right-4 z-40 flex h-[60px] w-[60px] items-center justify-center rounded-full border border-gray-6 bg-[linear-gradient(180deg,rgba(26,26,26,0.4)_0%,rgba(26,26,26,0.28)_100%)] text-gray-6 backdrop-blur-[5px] transition-colors duration-200 hover:bg-gray-6 hover:text-white',
+              // Offset above the Plain chat launcher so the controls do not overlap
+              'fixed bottom-24 right-4 z-40 flex h-[60px] w-[60px] items-center justify-center rounded-full border border-gray-6 bg-[linear-gradient(180deg,rgba(26,26,26,0.4)_0%,rgba(26,26,26,0.28)_100%)] text-gray-6 backdrop-blur-[5px] transition-colors duration-200 hover:bg-gray-6 hover:text-white',
               {
-                'sm:bottom-32': isCookieBannerVisible,
+                'sm:bottom-48': isCookieBannerVisible,
               }
             )}
             key="floating-button"
@@ -54,6 +55,7 @@ const FloatingButton = ({ isCookieBannerVisible }) => {
             animate="visible"
             exit="exit"
             type="button"
+            aria-label="Scroll to top"
             onClick={handleClick}
           >
             <Arrow className="h-[21px] w-[14px]" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Raises the homepage scroll-to-top button above the Plain live chat launcher so the two floating controls no longer overlap.
- Keeps additional bottom offset on small screens when the cookie banner is visible.
- Adds an accessible label on the icon-only scroll button.

## Test plan
- [ ] Open the homepage and scroll past the hero until the scroll-to-top button appears
- [ ] Confirm the scroll-to-top button sits clearly above the Plain chat launcher with a visible gap
- [ ] Confirm both controls are independently clickable
- [ ] On a mobile viewport, show the cookie banner and confirm the scroll-to-top button still clears both the banner and chat launcher

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8346](https://linear.app/novu/issue/NV-8346/floating-chat-widget-overlaps-with-scroll-to-top-button-on-the)

<div><a href="https://cursor.com/agents/bc-ba10297e-9033-4c45-ac68-da229ccdc0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba10297e-9033-4c45-ac68-da229ccdc0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

