### PR TITLE
feat: disable Novu Connect banner

### DIFF
--- a/src/data/link-banner.js
+++ b/src/data/link-banner.js
@@ -1,7 +1,7 @@
 const bannerData = {
   text: 'New: Novu Connect is live. Give your AI agent access to every channel in a single conversation.',
   url: '/connect',
-  isActive: true,
+  isActive: false,
   linkText: 'Try it free',
 };
 


### PR DESCRIPTION
## Summary

- Disable the Novu Connect promotional banner in the header using the existing `isActive` flag.
- Keep the banner configuration in place so it can be re-enabled later.

## Why

The “New: Novu Connect is live” header banner should no longer be displayed on the website.

## Impact

The banner is no longer rendered, so it no longer occupies space above the header.

## Validation

- `npm run lint:js` — completed with no errors (existing repository warnings remain).
- Pre-commit Prettier and ESLint hooks passed.