### PR TITLE
Add AI agent onboarding link to footer

### DIFF
--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -30,7 +30,7 @@ const ICONS = {
 
 const Footer = () => (
   <footer className="relative border-t border-dashed border-t-gray-4 bg-black px-8 pb-8 pt-12 lg:pt-12 md:pb-7 md:pt-10 sm:px-5 sm:pb-6">
-    <div className="mx-auto w-full max-w-[1344px]">
+    <div className="relative mx-auto w-full max-w-[1344px]">
       <div className="flex items-start gap-[122px] lg:flex-col lg:items-stretch lg:gap-10">
         <Link {...LINKS.home}>
           <span className="sr-only">Novu</span>
@@ -38,6 +38,17 @@ const Footer = () => (
         </Link>
         <Navigation />
       </div>
+      <p className="absolute right-0 top-[333px] w-72 text-right text-base leading-[1.375] -tracking-[0.02em] text-white/50 lg:static lg:mt-10 lg:w-full lg:text-left lg:tracking-normal">
+        AI agent looking to onboard?
+        <br />
+        Follow the instructions in{' '}
+        <Link
+          className="text-white underline transition-colors duration-200 hover:text-primary-1 focus-visible:text-primary-1"
+          to="https://novu.co/agents.md"
+        >
+          agents.md
+        </Link>
+      </p>
       <div className="mt-16 pt-px xl:pt-0 md:mt-18">
         <div className="flex justify-between pb-[26px] md:pb-[21px] sm:flex-col sm:justify-normal sm:pb-4">
           <SystemStatus />

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -31,24 +31,26 @@ const ICONS = {
 const Footer = () => (
   <footer className="relative border-t border-dashed border-t-gray-4 bg-black px-8 pb-8 pt-12 lg:pt-12 md:pb-7 md:pt-10 sm:px-5 sm:pb-6">
     <div className="relative mx-auto w-full max-w-[1344px]">
-      <div className="flex items-start gap-[122px] lg:flex-col lg:items-stretch lg:gap-10">
-        <Link {...LINKS.home}>
-          <span className="sr-only">Novu</span>
-          <Logo className="h-8" aria-hidden />
-        </Link>
-        <Navigation />
+      <div className="relative">
+        <div className="flex items-start gap-[122px] lg:flex-col lg:items-stretch lg:gap-10">
+          <Link {...LINKS.home}>
+            <span className="sr-only">Novu</span>
+            <Logo className="h-8" aria-hidden />
+          </Link>
+          <Navigation />
+        </div>
+        <p className="absolute bottom-0 right-0 w-72 text-right text-base leading-snug -tracking-[0.02em] text-white/50 lg:static lg:mt-10 lg:w-full lg:text-left lg:tracking-normal">
+          AI agent looking to onboard?
+          <br />
+          Follow the instructions in{' '}
+          <Link
+            className="text-white underline transition-colors duration-200 hover:text-primary-1 focus-visible:text-primary-1"
+            to="https://novu.co/agents.md"
+          >
+            agents.md
+          </Link>
+        </p>
       </div>
-      <p className="absolute right-0 top-[333px] w-72 text-right text-base leading-[1.375] -tracking-[0.02em] text-white/50 lg:static lg:mt-10 lg:w-full lg:text-left lg:tracking-normal">
-        AI agent looking to onboard?
-        <br />
-        Follow the instructions in{' '}
-        <Link
-          className="text-white underline transition-colors duration-200 hover:text-primary-1 focus-visible:text-primary-1"
-          to="https://novu.co/agents.md"
-        >
-          agents.md
-        </Link>
-      </p>
       <div className="mt-16 pt-px xl:pt-0 md:mt-18">
         <div className="flex justify-between pb-[26px] md:pb-[21px] sm:flex-col sm:justify-normal sm:pb-4">
           <SystemStatus />


### PR DESCRIPTION
## Summary
- Add AI agent onboarding copy to the footer.
- Link `agents.md` to https://novu.co/agents.md.
- Match the provided Figma placement with a responsive fallback.

## Validation
- `npx eslint --no-cache src/components/shared/footer/footer.jsx`
- `npx prettier --check src/components/shared/footer/footer.jsx`
- `git diff --check`

The full Gatsby build remains blocked by existing external data issues involving GitHub API access, the missing `Landing` template, and Better Stack status fetching.